### PR TITLE
precompiled: add support for x86-linux and aarch64-linux

### DIFF
--- a/.github/workflows/precompiled.yml
+++ b/.github/workflows/precompiled.yml
@@ -48,7 +48,7 @@ jobs:
         plat: ["x86_64-linux", "x86_64-darwin", "x64-mingw32"]
     runs-on: ubuntu-latest
     container:
-      image: "larskanis/rake-compiler-dock-mri-${{matrix.plat}}:1.1.0"
+      image: "larskanis/rake-compiler-dock-mri-${{matrix.plat}}:1.2.0"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2

--- a/.github/workflows/precompiled.yml
+++ b/.github/workflows/precompiled.yml
@@ -45,18 +45,23 @@ jobs:
       fail-fast: false
       matrix:
         # arm64-darwin is omitted until github actions supports it
-        plat: ["x86_64-linux", "x86_64-darwin", "x64-mingw32"]
+        plat:
+          - "x86-linux"
+          - "x86_64-linux"
+          - "x86_64-darwin"
+          - "x64-mingw32"
     runs-on: ubuntu-latest
-    container:
-      image: "larskanis/rake-compiler-dock-mri-${{matrix.plat}}:1.2.0"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
         with:
           path: precompiled/ports/archives
           key: archives-ubuntu-${{hashFiles('precompiled/ext/precompiled/extconf.rb')}}
-      - run: "./bin/test-gem-build gems ${{matrix.plat}}"
-        working-directory: precompiled
+      - run: |
+          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+          docker run --rm -v "$(pwd)/precompiled:/precompiled" -w /precompiled \
+            larskanis/rake-compiler-dock-mri-${{matrix.plat}}:1.2.0 \
+            ./bin/test-gem-build gems ${{matrix.plat}}
       - uses: actions/upload-artifact@v2
         with:
           name: "cruby-${{matrix.plat}}-gem"
@@ -81,6 +86,26 @@ jobs:
           path: precompiled/gems
       - run: ./bin/test-gem-install gems
         working-directory: precompiled
+
+  cruby-x86-linux-install:
+    needs: ["cruby-native-package"]
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["2.6", "2.7", "3.0", "3.1"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: cruby-x86-linux-gem
+          path: precompiled/gems
+      - run: |
+          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+          docker run --rm -v "$(pwd)/precompiled:/precompiled" -w /precompiled \
+            --platform=linux/386 \
+            ruby:${{matrix.ruby}} \
+            ./bin/test-gem-install ./gems
 
   cruby-x86_64-musl-install:
     needs: ["cruby-native-package"]

--- a/.github/workflows/precompiled.yml
+++ b/.github/workflows/precompiled.yml
@@ -61,11 +61,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # arm64-darwin is omitted until github actions supports it
         plat:
           - "x86-linux"
           - "x86_64-linux"
+          - "aarch64-linux"
           - "x86_64-darwin"
+#          - "arm64-darwin" # omitted until github actions supports it
           - "x64-mingw32"
           - "x64-mingw-ucrt"
     runs-on: ubuntu-latest
@@ -125,6 +126,26 @@ jobs:
             ruby:${{matrix.ruby}} \
             ./bin/test-gem-install ./gems
 
+  cruby-aarch64-linux-install:
+    needs: ["cruby-native-package"]
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["2.6", "2.7", "3.0", "3.1"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: cruby-aarch64-linux-gem
+          path: precompiled/gems
+      - run: |
+          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+          docker run --rm -v "$(pwd)/precompiled:/precompiled" -w /precompiled \
+            --platform=linux/arm64/v8 \
+            ruby:${{matrix.ruby}} \
+            ./bin/test-gem-install ./gems
+
   cruby-x86_64-musl-install:
     needs: ["cruby-native-package"]
     strategy:
@@ -162,6 +183,10 @@ jobs:
           path: precompiled/gems
       - run: ./bin/test-gem-install gems
         working-directory: precompiled
+
+## arm64-darwin installation testing is omitted until github actions supports it
+#  cruby-arm64-darwin-install:
+#    ...
 
   cruby-x64-mingw32-install:
     needs: ["cruby-native-package"]

--- a/.github/workflows/precompiled.yml
+++ b/.github/workflows/precompiled.yml
@@ -23,14 +23,31 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ["2.6", "2.7", "3.0", "3.1"]
-        runs-on: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        runs-on: ["ubuntu-latest", "macos-latest"]
+        include:
+          - ruby: "2.6"
+            runs-on: "windows-2019"
+          - ruby: "2.7"
+            runs-on: "windows-2019"
+          - ruby: "3.0"
+            runs-on: "windows-2019"
+          - ruby: "3.1"
+            runs-on: "windows-2022"
     runs-on: ${{matrix.runs-on}}
     steps:
       - uses: actions/checkout@v2
-      - uses: ruby/setup-ruby@v1
+      - if: ${{ matrix.runs-on != 'windows-2022' }}
+        uses: ruby/setup-ruby@v1
         with:
           working-directory: precompiled
           ruby-version: ${{matrix.ruby}}
+          bundler-cache: true
+      - if: ${{ matrix.runs-on == 'windows-2022' }}
+        uses: MSP-Greg/setup-ruby-pkgs@win-ucrt-2
+        with:
+          working-directory: precompiled
+          setup-ruby-ref: MSP-Greg/ruby-setup-ruby/win-ucrt-1
+          ruby-version: "${{matrix.ruby}}"
           bundler-cache: true
       - uses: actions/cache@v2
         with:
@@ -50,6 +67,7 @@ jobs:
           - "x86_64-linux"
           - "x86_64-darwin"
           - "x64-mingw32"
+          - "x64-mingw-ucrt"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -150,8 +168,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1"]
-    runs-on: windows-latest
+        ruby: ["2.6", "2.7", "3.0"]
+    runs-on: windows-2019
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
@@ -160,6 +178,26 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: cruby-x64-mingw32-gem
+          path: precompiled/gems
+      - run: ./bin/test-gem-install gems
+        working-directory: precompiled
+
+  cruby-x64-mingw-ucrt-install:
+    needs: ["cruby-native-package"]
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["3.1"]
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v2
+      - uses: MSP-Greg/setup-ruby-pkgs@win-ucrt-2
+        with:
+          ruby-version: "${{matrix.ruby}}"
+          setup-ruby-ref: MSP-Greg/ruby-setup-ruby/win-ucrt-1
+      - uses: actions/download-artifact@v2
+        with:
+          name: cruby-x64-mingw-ucrt-gem
           path: precompiled/gems
       - run: ./bin/test-gem-install gems
         working-directory: precompiled

--- a/.github/workflows/precompiled.yml
+++ b/.github/workflows/precompiled.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.5", "2.6", "2.7", "3.0"]
+        ruby: ["2.6", "2.7", "3.0", "3.1"]
         runs-on: ["ubuntu-latest", "macos-latest", "windows-latest"]
     runs-on: ${{matrix.runs-on}}
     steps:
@@ -68,7 +68,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.5", "2.6", "2.7", "3.0"]
+        ruby: ["2.6", "2.7", "3.0", "3.1"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -87,7 +87,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.5", "2.6", "2.7", "3.0"]
+        ruby: ["2.6", "2.7", "3.0", "3.1"]
     runs-on: ubuntu-latest
     container:
       image: "ruby:${{matrix.ruby}}-alpine"
@@ -106,7 +106,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.5", "2.6", "2.7", "3.0"]
+        ruby: ["2.6", "2.7", "3.0", "3.1"]
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
@@ -125,7 +125,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.5", "2.6", "2.7", "3.0"]
+        ruby: ["2.6", "2.7", "3.0", "3.1"]
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2

--- a/precompiled/Gemfile
+++ b/precompiled/Gemfile
@@ -8,6 +8,6 @@ gemspec
 gem "rake", "~> 13.0"
 
 gem "rake-compiler"
-gem "rake-compiler-dock"
+gem "rake-compiler-dock", "~> 1.2.0"
 
 gem "minitest", "~> 5.0"

--- a/precompiled/README.md
+++ b/precompiled/README.md
@@ -26,8 +26,16 @@ This is really powerful stuff, and once we assume that we can cross-compile reli
 First, we need to add some features to our `Rake::ExtensionTask` in `Rakefile`:
 
 ``` ruby
-cross_rubies = ["3.0.0", "2.7.0", "2.6.0", "2.5.0"]
-cross_platforms = ["x64-mingw32", "x86_64-linux", "x86_64-darwin", "arm64-darwin"]
+cross_rubies = ["3.1.0", "3.0.0", "2.7.0", "2.6.0"]
+cross_platforms = [
+  "x64-mingw32",
+  "x64-mingw-ucrt",
+  "x86-linux",
+  "x86_64-linux",
+  "aarch64-linux",
+  "x86_64-darwin",
+  "arm64-darwin",
+]
 ENV["RUBY_CC_VERSION"] = cross_rubies.join(":")
 
 Rake::ExtensionTask.new("precompiled", rcee_precompiled_spec) do |ext|
@@ -120,13 +128,13 @@ We have one more small change we'll need to make to how the extension is require
 lib
 └── rcee
     ├── precompiled
-    │   ├── 2.5
-    │   │   └── precompiled.so
     │   ├── 2.6
     │   │   └── precompiled.so
     │   ├── 2.7
     │   │   └── precompiled.so
     │   ├── 3.0
+    │   │   └── precompiled.so
+    │   ├── 3.1
     │   │   └── precompiled.so
     │   └── version.rb
     └── precompiled.rb

--- a/precompiled/Rakefile
+++ b/precompiled/Rakefile
@@ -7,7 +7,13 @@ require "rake/extensiontask"
 require "rake_compiler_dock"
 
 cross_rubies = ["3.1.0", "3.0.0", "2.7.0", "2.6.0"]
-cross_platforms = ["x64-mingw32", "x86_64-linux", "x86_64-darwin", "arm64-darwin"]
+cross_platforms = [
+  "x64-mingw32",
+  "x86-linux",
+  "x86_64-linux",
+  "x86_64-darwin",
+  "arm64-darwin",
+]
 ENV["RUBY_CC_VERSION"] = cross_rubies.join(":")
 
 rcee_precompiled_spec = Bundler.load_gemspec("rcee_precompiled.gemspec")

--- a/precompiled/Rakefile
+++ b/precompiled/Rakefile
@@ -9,6 +9,7 @@ require "rake_compiler_dock"
 cross_rubies = ["3.1.0", "3.0.0", "2.7.0", "2.6.0"]
 cross_platforms = [
   "x64-mingw32",
+  "x64-mingw-ucrt",
   "x86-linux",
   "x86_64-linux",
   "x86_64-darwin",

--- a/precompiled/Rakefile
+++ b/precompiled/Rakefile
@@ -12,6 +12,7 @@ cross_platforms = [
   "x64-mingw-ucrt",
   "x86-linux",
   "x86_64-linux",
+  "aarch64-linux",
   "x86_64-darwin",
   "arm64-darwin",
 ]

--- a/precompiled/Rakefile
+++ b/precompiled/Rakefile
@@ -6,7 +6,7 @@ require "rake/testtask"
 require "rake/extensiontask"
 require "rake_compiler_dock"
 
-cross_rubies = ["3.0.0", "2.7.0", "2.6.0", "2.5.0"]
+cross_rubies = ["3.1.0", "3.0.0", "2.7.0", "2.6.0"]
 cross_platforms = ["x64-mingw32", "x86_64-linux", "x86_64-darwin", "arm64-darwin"]
 ENV["RUBY_CC_VERSION"] = cross_rubies.join(":")
 

--- a/precompiled/rcee_precompiled.gemspec
+++ b/precompiled/rcee_precompiled.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.summary       = "Example gem demonstrating a basic C extension."
   spec.description   = "Part of a project to explain how Ruby C extensions work."
   spec.homepage      = "https://github.com/flavorjones/ruby-c-extensions-explained"
-  spec.required_ruby_version = ">= 2.5.0"
+  spec.required_ruby_version = ">= 2.6.0"
   spec.license = "MIT"
 
   # Specify which files should be added to the gem when it is released.


### PR DESCRIPTION
Add support for x86-linux and aarch64-linux, including a demonstration of how to CI these architectures using github actions.
