### PR TITLE
ci: bump ruby matrix to 2.6..3.1

### DIFF
--- a/.github/workflows/isolated.yml
+++ b/.github/workflows/isolated.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.5", "2.6", "2.7", "3.0"]
+        ruby: ["2.6", "2.7", "3.0", "3.1"]
         runs-on: ["ubuntu-latest", "macos-latest", "windows-latest"]
     runs-on: ${{matrix.runs-on}}
     steps:

--- a/.github/workflows/packaged_source.yml
+++ b/.github/workflows/packaged_source.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.5", "2.6", "2.7", "3.0"]
+        ruby: ["2.6", "2.7", "3.0", "3.1"]
         runs-on: ["ubuntu-latest", "macos-latest", "windows-latest"]
     runs-on: ${{matrix.runs-on}}
     steps:

--- a/.github/workflows/packaged_tarball.yml
+++ b/.github/workflows/packaged_tarball.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.5", "2.6", "2.7", "3.0"]
+        ruby: ["2.6", "2.7", "3.0", "3.1"]
         runs-on: ["ubuntu-latest", "macos-latest", "windows-latest"]
     runs-on: ${{matrix.runs-on}}
     steps:

--- a/.github/workflows/precompiled.yml
+++ b/.github/workflows/precompiled.yml
@@ -43,10 +43,9 @@ jobs:
           ruby-version: ${{matrix.ruby}}
           bundler-cache: true
       - if: ${{ matrix.runs-on == 'windows-2022' }}
-        uses: MSP-Greg/setup-ruby-pkgs@win-ucrt-2
+        uses: MSP-Greg/setup-ruby-pkgs@v1
         with:
           working-directory: precompiled
-          setup-ruby-ref: MSP-Greg/ruby-setup-ruby/win-ucrt-1
           ruby-version: "${{matrix.ruby}}"
           bundler-cache: true
       - uses: actions/cache@v2
@@ -215,10 +214,9 @@ jobs:
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v2
-      - uses: MSP-Greg/setup-ruby-pkgs@win-ucrt-2
+      - uses: MSP-Greg/setup-ruby-pkgs@v1
         with:
           ruby-version: "${{matrix.ruby}}"
-          setup-ruby-ref: MSP-Greg/ruby-setup-ruby/win-ucrt-1
       - uses: actions/download-artifact@v2
         with:
           name: cruby-x64-mingw-ucrt-gem

--- a/.github/workflows/system.yml
+++ b/.github/workflows/system.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.5", "2.6", "2.7", "3.0"]
+        ruby: ["2.6", "2.7", "3.0", "3.1"]
         runs-on: ["ubuntu-latest", "macos-latest", "windows-latest"]
     runs-on: ${{matrix.runs-on}}
     steps:


### PR DESCRIPTION
Pipelines (except precompiled) were still running Ruby 2.5 but not Ruby 3.1. This updates CI to use only the 4 most recent versions of Ruby.