### PR TITLE
dep: support Ruby 3.2, drop Ruby 2.6

### DIFF
--- a/.github/workflows/isolated.yml
+++ b/.github/workflows/isolated.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1"]
+        ruby: ["2.7", "3.0", "3.1", "3.2"]
         runs-on: ["ubuntu-latest", "macos-latest", "windows-latest"]
     runs-on: ${{matrix.runs-on}}
     steps:

--- a/.github/workflows/packaged_source.yml
+++ b/.github/workflows/packaged_source.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1"]
+        ruby: ["2.7", "3.0", "3.1", "3.2"]
         runs-on: ["ubuntu-latest", "macos-latest", "windows-latest"]
     runs-on: ${{matrix.runs-on}}
     steps:

--- a/.github/workflows/packaged_tarball.yml
+++ b/.github/workflows/packaged_tarball.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1"]
+        ruby: ["2.7", "3.0", "3.1", "3.2"]
         runs-on: ["ubuntu-latest", "macos-latest", "windows-latest"]
     runs-on: ${{matrix.runs-on}}
     steps:

--- a/.github/workflows/precompiled.yml
+++ b/.github/workflows/precompiled.yml
@@ -23,15 +23,15 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: ["ubuntu-latest", "macos-latest"]
-        ruby: ["2.6", "2.7", "3.0", "3.1"]
+        ruby: ["2.7", "3.0", "3.1", "3.2"]
         include:
-          - ruby: "2.6"
-            runs-on: "windows-2019"
           - ruby: "2.7"
             runs-on: "windows-2019"
           - ruby: "3.0"
             runs-on: "windows-2019"
           - ruby: "3.1"
+            runs-on: "windows-2022"
+          - ruby: "3.2"
             runs-on: "windows-2022"
     runs-on: ${{matrix.runs-on}}
     steps:
@@ -59,7 +59,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           working-directory: precompiled
-          ruby-version: "3.1"
+          ruby-version: "3.2"
           bundler-cache: true
       - run: ./bin/test-gem-build gems ruby
         working-directory: precompiled
@@ -74,7 +74,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "head"]
+        ruby: ["2.7", "3.0", "3.1", "3.2", "head"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -94,7 +94,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1"]
+        ruby: ["3.2"]
         sys: ["enable", "disable"]
     runs-on: macos-latest
     steps:
@@ -123,7 +123,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           working-directory: precompiled
-          ruby-version: "3.0"
+          ruby-version: ${{matrix.ruby}}
       - uses: actions/download-artifact@v2
         with:
           name: cruby-gem
@@ -139,7 +139,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1"]
+        ruby: ["3.2"]
         sys: ["enable", "disable"]
     runs-on: windows-2022
     steps:
@@ -147,7 +147,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           working-directory: precompiled
-          ruby-version: "3.0"
+          ruby-version: ${{matrix.ruby}}
       - uses: actions/download-artifact@v2
         with:
           name: cruby-gem
@@ -158,7 +158,24 @@ jobs:
           ruby -r rcee/precompiled -e 'puts ::RCEE::Precompiled::Extension.do_something'
         working-directory: precompiled
 
+  rcd_image_version:
+    runs-on: ubuntu-latest
+    outputs:
+      rcd_image_version: ${{steps.rcd_image_version.outputs.rcd_image_version}}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          working-directory: precompiled
+          ruby-version: "3.2"
+          bundler-cache: true
+          bundler: latest
+      - id: rcd_image_version
+        run: bundle exec ruby -e 'require "rake_compiler_dock"; puts "rcd_image_version=#{RakeCompilerDock::IMAGE_VERSION}"' >> $GITHUB_OUTPUT
+        working-directory: precompiled
+
   cruby-native-package:
+    needs: ["rcd_image_version"]
     strategy:
       fail-fast: false
       matrix:
@@ -178,9 +195,11 @@ jobs:
         with:
           path: precompiled/ports/archives
           key: archives-ubuntu-${{hashFiles('precompiled/ext/precompiled/extconf.rb')}}
-      - run: |
+      - env:
+          DOCKER_IMAGE: "ghcr.io/rake-compiler/rake-compiler-dock-image:${{needs.rcd_image_version.outputs.rcd_image_version}}-mri-${{matrix.plat}}"
+        run: |
           docker run --rm -v "$(pwd)/precompiled:/precompiled" -w /precompiled \
-            larskanis/rake-compiler-dock-mri-${{matrix.plat}}:1.2.0 \
+            ${DOCKER_IMAGE} \
             ./bin/test-gem-build gems ${{matrix.plat}}
       - uses: actions/upload-artifact@v2
         with:
@@ -193,7 +212,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1"]
+        ruby: ["2.7", "3.0", "3.1", "3.2"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -212,7 +231,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1"]
+        ruby: ["2.7", "3.0", "3.1", "3.2"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -232,7 +251,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1"]
+        ruby: ["2.7", "3.0", "3.1", "3.2"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -252,7 +271,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1"]
+        ruby: ["2.7", "3.0", "3.1", "3.2"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -272,7 +291,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1"]
+        ruby: ["2.7", "3.0", "3.1", "3.2"]
     runs-on: ubuntu-latest
     container:
       image: "ruby:${{matrix.ruby}}-alpine"
@@ -291,7 +310,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1"]
+        ruby: ["2.7", "3.0", "3.1", "3.2"]
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
@@ -314,7 +333,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0"]
+        ruby: ["2.7", "3.0"]
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v2
@@ -333,7 +352,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1"]
+        ruby: ["3.1", "3.2"]
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/system.yml
+++ b/.github/workflows/system.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1"]
+        ruby: ["2.7", "3.0", "3.1", "3.2"]
         runs-on: ["ubuntu-latest", "macos-latest", "windows-latest"]
     runs-on: ${{matrix.runs-on}}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## next / unreleased
+
+### Added
+
+- `precompiled` gem now supports Ruby 3.2 and drops support for Ruby 2.6
+
+
 ## 0.4.0 / 2022-05-19
 
 ### Added

--- a/isolated/test/isolated_test.rb
+++ b/isolated/test/isolated_test.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-class IsolatedTest < MiniTest::Spec
+class IsolatedTest < Minitest::Spec
   describe "Isolated" do
     it "defines a class" do
       assert(defined?(::RCEE::Isolated::Extension))

--- a/precompiled/Gemfile
+++ b/precompiled/Gemfile
@@ -8,6 +8,6 @@ gemspec
 gem "rake", "~> 13.0"
 
 gem "rake-compiler"
-gem "rake-compiler-dock", "~> 1.2.1"
+gem "rake-compiler-dock", "~> 1.3.0"
 
 gem "minitest", "~> 5.0"

--- a/precompiled/README.md
+++ b/precompiled/README.md
@@ -26,7 +26,7 @@ This is really powerful stuff, and once we assume that we can cross-compile reli
 First, we need to add some features to our `Rake::ExtensionTask` in `Rakefile`:
 
 ``` ruby
-cross_rubies = ["3.1.0", "3.0.0", "2.7.0", "2.6.0"]
+cross_rubies = ["3.2.0", "3.1.0", "3.0.0", "2.7.0"]
 cross_platforms = [
   "x64-mingw32",
   "x64-mingw-ucrt",
@@ -128,13 +128,13 @@ We have one more small change we'll need to make to how the extension is require
 lib
 └── rcee
     ├── precompiled
-    │   ├── 2.6
-    │   │   └── precompiled.so
     │   ├── 2.7
     │   │   └── precompiled.so
     │   ├── 3.0
     │   │   └── precompiled.so
     │   ├── 3.1
+    │   │   └── precompiled.so
+    │   ├── 3.2
     │   │   └── precompiled.so
     │   └── version.rb
     └── precompiled.rb

--- a/precompiled/Rakefile
+++ b/precompiled/Rakefile
@@ -6,7 +6,7 @@ require "rake/testtask"
 require "rake/extensiontask"
 require "rake_compiler_dock"
 
-cross_rubies = ["3.1.0", "3.0.0", "2.7.0", "2.6.0"]
+cross_rubies = ["3.2.0", "3.1.0", "3.0.0", "2.7.0"]
 cross_platforms = [
   "aarch64-linux",
   "arm-linux",

--- a/precompiled/rcee_precompiled.gemspec
+++ b/precompiled/rcee_precompiled.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.summary       = "Example gem demonstrating a basic C extension."
   spec.description   = "Part of a project to explain how Ruby C extensions work."
   spec.homepage      = "https://github.com/flavorjones/ruby-c-extensions-explained"
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 2.7.0"
   spec.license = "MIT"
 
   # Specify which files should be added to the gem when it is released.


### PR DESCRIPTION
also prefer `Minitest` to `MiniTest` because the latter is no longer supported by `minitest`