### PR TITLE
RUBY_FUNC_EXPORTED for init function

### DIFF
--- a/system/ext/system/system.c
+++ b/system/ext/system/system.c
@@ -15,7 +15,7 @@ rb_system_extension_class_do_something(VALUE self)
 }
 
 
-void
+RUBY_FUNC_EXPORTED void
 Init_system(void)
 {
   rb_mRCEE = rb_define_module("RCEE");


### PR DESCRIPTION
This is something I noticed other native extensions do - do you know if this is necessary?

@flavorjones 