### PR TITLE
modernize extconfs

### DIFF
--- a/packaged_source/README.md
+++ b/packaged_source/README.md
@@ -37,15 +37,25 @@ ext/
 The `extconf.rb` contains some new code:
 
 ``` ruby
+# $VPATH is used as the Makefile's $(VPATH) variable
+# see https://www.gnu.org/software/make/manual/html_node/General-Search.html
 $VPATH << "$(srcdir)/yaml"
+
+# $srcs is normally set to the list of C files in the extension directory,
+# but we need to append the libyaml files to it.
 $srcs = Dir.glob("#{$srcdir}/{,yaml/}*.c").map { |n| File.basename(n) }.sort
+
+# and make sure that the C preprocessor includes the yaml directory in its search path
 append_cppflags("-I$(srcdir)/yaml")
 
-find_header("yaml.h")
+# assert that we can find the yaml.h header file
+abort("could not find yaml.h") unless find_header("yaml.h")
+
+# defines HAVE_CONFIG_H macro
 have_header("config.h")
 ```
 
-It first configures `MakeMakefile` to pay attention to the `./yaml` directory as well as the C and header files. It then verifies that `yaml.h` can be found (we could skip this since we're packing it and setting the include path manually). Finally, a libyaml-specific action is taken which is to make sure `config.h` can be found and that the `HAVE_CONFIG_H` macro is set so that `yaml.h` is compiled properly.
+It first configures `MakeMakefile` to pay attention to the `./yaml` directory as well as the C and header files. It then verifies that `yaml.h` can be found (though we could probably skip this step). Finally, a libyaml-specific action is taken which is to make sure `config.h` can be found and that the `HAVE_CONFIG_H` macro is set so that `yaml.h` is compiled properly.
 
 The `Makefile` recipe looks something like:
 

--- a/packaged_source/ext/packaged_source/extconf.rb
+++ b/packaged_source/ext/packaged_source/extconf.rb
@@ -1,10 +1,20 @@
 require "mkmf"
 
+# $VPATH is used as the Makefile's $(VPATH) variable
+# see https://www.gnu.org/software/make/manual/html_node/General-Search.html
 $VPATH << "$(srcdir)/yaml"
+
+# $srcs is normally set to the list of C files in the extension directory,
+# but we need to append the libyaml files to it.
 $srcs = Dir.glob("#{$srcdir}/{,yaml/}*.c").map { |n| File.basename(n) }.sort
+
+# and make sure that the C preprocessor includes the yaml directory in its search path
 append_cppflags("-I$(srcdir)/yaml")
 
-find_header("yaml.h")
-have_header("config.h") # defines HAVE_CONFIG_H macro
+# assert that we can find the yaml.h header file
+abort("could not find yaml.h") unless find_header("yaml.h")
+
+# defines HAVE_CONFIG_H macro
+have_header("config.h")
 
 create_makefile("rcee/packaged_source/packaged_source")

--- a/packaged_tarball/ext/packaged_tarball/extconf.rb
+++ b/packaged_tarball/ext/packaged_tarball/extconf.rb
@@ -1,24 +1,58 @@
 require "mkmf"
 require "mini_portile2"
 
-package_root_dir = File.expand_path(File.join(File.dirname(__FILE__), "..", ".."))
+module RCEE
+  module PackagedTarball
+    module ExtConf
+      PACKAGE_ROOT_DIR = File.expand_path(File.join(File.dirname(__FILE__), "..", ".."))
 
-MiniPortile.new("yaml", "0.2.5").tap do |recipe|
-  recipe.files = [{
-    url: "https://github.com/yaml/libyaml/releases/download/0.2.5/yaml-0.2.5.tar.gz",
-    sha256: "c642ae9b75fee120b2d96c712538bd2cf283228d2337df2cf2988e3c02678ef4",
-  }]
+      class << self
+        def configure
+          configure_packaged_libraries
 
-  recipe.target = File.join(package_root_dir, "ports")
-  unless File.exist?(File.join(recipe.target, recipe.host, recipe.name, recipe.version))
-    recipe.cook
+          create_makefile("rcee/packaged_tarball/packaged_tarball")
+        end
+
+        def configure_packaged_libraries
+          recipe = libyaml_recipe
+
+          # ensure libyaml has already been unpacked, configured, and compiled
+          unless File.exist?(File.join(recipe.target, recipe.host, recipe.name, recipe.version))
+            recipe.cook
+          end
+
+          # use the packaged libyaml
+          recipe.activate
+          pkg_config(File.join(recipe.path, "lib", "pkgconfig", "yaml-0.1.pc"))
+
+          # assert that we can build against the packaged libyaml
+          unless have_library("yaml", "yaml_get_version", "yaml.h")
+            abort("\nERROR: *** could not find libyaml development environment ***\n\n")
+          end
+        end
+
+        def download
+          libyaml_recipe.download
+        end
+
+        def libyaml_recipe
+          MiniPortile.new("yaml", "0.2.5").tap do |recipe|
+            recipe.files = [{
+              url: "https://github.com/yaml/libyaml/releases/download/0.2.5/yaml-0.2.5.tar.gz",
+              sha256: "c642ae9b75fee120b2d96c712538bd2cf283228d2337df2cf2988e3c02678ef4"
+            }]
+            recipe.target = File.join(PACKAGE_ROOT_DIR, "ports")
+          end
+        end
+      end
+    end
   end
-  recipe.activate
-  pkg_config(File.join(recipe.path, "lib", "pkgconfig", "yaml-0.1.pc"))
 end
 
-unless have_library("yaml", "yaml_get_version", "yaml.h")
-  abort("\nERROR: *** could not find libyaml development environment ***\n\n")
+# run "ruby ./ext/packaged_tarball/extconf.rb -- --download-dependencies" to download the tarball
+if arg_config("--download-dependencies")
+  RCEE::PackagedTarball::ExtConf.download
+  exit!(0)
 end
 
-create_makefile("rcee/packaged_tarball/packaged_tarball")
+RCEE::PackagedTarball::ExtConf.configure

--- a/precompiled/ext/precompiled/extconf.rb
+++ b/precompiled/ext/precompiled/extconf.rb
@@ -1,41 +1,78 @@
 require "mkmf"
 require "mini_portile2"
 
-package_root_dir = File.expand_path(File.join(File.dirname(__FILE__), "..", ".."))
+module RCEE
+  module Precompiled
+    module ExtConf
+      PACKAGE_ROOT_DIR = File.expand_path(File.join(File.dirname(__FILE__), "..", ".."))
 
-RbConfig::CONFIG["CC"] = RbConfig::MAKEFILE_CONFIG["CC"] = ENV["CC"] if ENV["CC"]
-ENV["CC"] = RbConfig::CONFIG["CC"]
+      class << self
+        def configure
+          configure_cross_compilers
+          configure_packaged_libraries
+          create_makefile("rcee/precompiled/precompiled")
+        end
 
-cross_build_p = enable_config("cross-build")
+        def configure_cross_compilers
+          RbConfig::CONFIG["CC"] = RbConfig::MAKEFILE_CONFIG["CC"] = ENV["CC"] if ENV["CC"]
+          ENV["CC"] = RbConfig::CONFIG["CC"]
+        end
 
-MiniPortile.new("yaml", "0.2.5").tap do |recipe|
-  recipe.files = [{
-    url: "https://github.com/yaml/libyaml/releases/download/0.2.5/yaml-0.2.5.tar.gz",
-    sha256: "c642ae9b75fee120b2d96c712538bd2cf283228d2337df2cf2988e3c02678ef4",
-  }]
-  recipe.target = File.join(package_root_dir, "ports")
+        def configure_packaged_libraries
+          recipe = libyaml_recipe
 
-  # configure the environment that MiniPortile will use for subshells
-  if cross_build_p
-    ENV.to_h.tap do |env|
-      # -fPIC is necessary for linking into a shared library
-      env["CFLAGS"] = [env["CFLAGS"], "-fPIC"].join(" ")
-      env["SUBDIRS"] = "include src" # libyaml: skip tests
+          # pass some environment variables to the libyaml configuration for cross-compilation
+          if cross_build?
+            ENV.to_h.tap do |env|
+              # -fPIC is necessary for linking into a shared library
+              env["CFLAGS"] = [env["CFLAGS"], "-fPIC"].join(" ")
+              env["SUBDIRS"] = "include src" # libyaml: skip tests
 
-      recipe.configure_options += env.map { |key, value| "#{key}=#{value.strip}" }
+              recipe.configure_options += env.map { |key, value| "#{key}=#{value.strip}" }
+            end
+          end
+
+          # ensure libyaml has already been unpacked, configured, and compiled
+          unless File.exist?(File.join(recipe.target, recipe.host, recipe.name, recipe.version))
+            recipe.cook
+          end
+
+          # use the packaged libyaml
+          recipe.activate
+          pkg_config(File.join(recipe.path, "lib", "pkgconfig", "yaml-0.1.pc"))
+
+          # assert that we can build against the packaged libyaml
+          unless have_library("yaml", "yaml_get_version", "yaml.h")
+            abort("\nERROR: *** could not find libyaml development environment ***\n\n")
+          end
+        end
+
+        def cross_build?
+          enable_config("cross-build")
+        end
+
+        def download
+          libyaml_recipe.download
+        end
+
+        def libyaml_recipe
+          MiniPortile.new("yaml", "0.2.5").tap do |recipe|
+            recipe.files = [{
+              url: "https://github.com/yaml/libyaml/releases/download/0.2.5/yaml-0.2.5.tar.gz",
+              sha256: "c642ae9b75fee120b2d96c712538bd2cf283228d2337df2cf2988e3c02678ef4"
+            }]
+            recipe.target = File.join(PACKAGE_ROOT_DIR, "ports")
+          end
+        end
+      end
     end
   end
-
-  unless File.exist?(File.join(recipe.target, recipe.host, recipe.name, recipe.version))
-    recipe.cook
-  end
-
-  recipe.activate
-  pkg_config(File.join(recipe.path, "lib", "pkgconfig", "yaml-0.1.pc"))
 end
 
-unless have_library("yaml", "yaml_get_version", "yaml.h")
-  abort("\nERROR: *** could not find libyaml development environment ***\n\n")
+# run "ruby ./ext/precompiled/extconf.rb -- --download-dependencies" to download the tarball
+if arg_config("--download-dependencies")
+  RCEE::Precompiled::ExtConf.download
+  exit!(0)
 end
 
-create_makefile("rcee/precompiled/precompiled")
+RCEE::Precompiled::ExtConf.configure


### PR DESCRIPTION
For the more complex `extconf.rb` files, let's demonstrate how to use a module with descriptive method names.