### PR TITLE
update gems to support ruby 3.3

### DIFF
--- a/.github/workflows/isolated.yml
+++ b/.github/workflows/isolated.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["3.0", "3.1", "3.2", "3.3", "head"]
         runs-on: ["ubuntu-latest", "macos-latest", "windows-latest"]
     runs-on: ${{matrix.runs-on}}
     steps:

--- a/.github/workflows/packaged_source.yml
+++ b/.github/workflows/packaged_source.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["3.0", "3.1", "3.2", "3.3", "head"]
         runs-on: ["ubuntu-latest", "macos-latest", "windows-latest"]
     runs-on: ${{matrix.runs-on}}
     steps:

--- a/.github/workflows/packaged_tarball.yml
+++ b/.github/workflows/packaged_tarball.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["3.0", "3.1", "3.2", "3.3", "head"]
         runs-on: ["ubuntu-latest", "macos-latest", "windows-latest"]
     runs-on: ${{matrix.runs-on}}
     steps:

--- a/.github/workflows/precompiled.yml
+++ b/.github/workflows/precompiled.yml
@@ -22,20 +22,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: ["ubuntu-latest", "macos-latest"]
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
-        include:
-          - ruby: "2.7"
-            runs-on: "windows-2019"
-          - ruby: "3.0"
-            runs-on: "windows-2019"
-          - ruby: "3.1"
-            runs-on: "windows-2022"
-          - ruby: "3.2"
-            runs-on: "windows-2022"
+        runs-on: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        ruby: ["3.0", "3.1", "3.2", "3.3", "head"]
     runs-on: ${{matrix.runs-on}}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           working-directory: precompiled
@@ -51,7 +42,7 @@ jobs:
   cruby-package:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/cache@v2
         with:
           path: precompiled/ports/archives
@@ -69,94 +60,27 @@ jobs:
           path: precompiled/gems
           retention-days: 1
 
-  cruby-linux-install:
-    needs: ["cruby-package"]
+  cruby-install:
+    needs: "cruby-package"
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2", "head"]
-    runs-on: ubuntu-latest
+        os: ["ubuntu", "macos", "windows"]
+        ruby: ["3.0", "3.1", "3.2", "3.3", "head"]
+    runs-on: ${{ matrix.os }}-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           working-directory: precompiled
-          ruby-version: "${{matrix.ruby}}"
+          ruby-version: "${{ matrix.ruby }}"
       - uses: actions/download-artifact@v2
         with:
           name: cruby-gem
           path: precompiled/gems
       - run: ./bin/test-gem-install gems
         working-directory: precompiled
-
-  cruby-osx-install:
-    needs: ["cruby-package"]
-    strategy:
-      fail-fast: false
-      matrix:
-        ruby: ["3.2"]
-        sys: ["enable", "disable"]
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ruby/setup-ruby@v1
-        with:
-          working-directory: precompiled
-          ruby-version: "${{matrix.ruby}}"
-      - uses: actions/download-artifact@v2
-        with:
-          name: cruby-gem
-          path: precompiled/gems
-      - run: ./bin/test-gem-install gems
-        working-directory: precompiled
-
-  cruby-windows-install:
-    needs: ["cruby-package"]
-    strategy:
-      fail-fast: false
-      matrix:
-        ruby: ["3.0"]
-        sys: ["enable", "disable"]
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ruby/setup-ruby@v1
-        with:
-          working-directory: precompiled
-          ruby-version: ${{matrix.ruby}}
-      - uses: actions/download-artifact@v2
-        with:
-          name: cruby-gem
-          path: precompiled/gems
-      - run: |
-          gem install --verbose --no-document gems/*.gem
-          gem list -d rcee_precompiled
-          ruby -r rcee/precompiled -e 'puts ::RCEE::Precompiled::Extension.do_something'
-        working-directory: precompiled
-
-  cruby-windows-install-ucrt:
-    needs: ["cruby-package"]
-    strategy:
-      fail-fast: false
-      matrix:
-        ruby: ["3.2"]
-        sys: ["enable", "disable"]
-    runs-on: windows-2022
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ruby/setup-ruby@v1
-        with:
-          working-directory: precompiled
-          ruby-version: ${{matrix.ruby}}
-      - uses: actions/download-artifact@v2
-        with:
-          name: cruby-gem
-          path: precompiled/gems
-      - run: |
-          gem install --verbose --no-document gems/*.gem
-          gem list -d rcee_precompiled
-          ruby -r rcee/precompiled -e 'puts ::RCEE::Precompiled::Extension.do_something'
-        working-directory: precompiled
+        shell: bash
 
   rcd_image_version:
     runs-on: ubuntu-latest
@@ -179,10 +103,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        plat:
+        platform:
           - "aarch64-linux"
           - "arm-linux"
-          # - "arm64-darwin" # omitted until github actions supports it
+          - "arm64-darwin" # github actions does not support this runtime, but let's build anyway
           - "x64-mingw-ucrt"
           - "x64-mingw32"
           - "x86-linux"
@@ -190,113 +114,61 @@ jobs:
           - "x86_64-linux"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/cache@v2
         with:
           path: precompiled/ports/archives
           key: archives-ubuntu-${{hashFiles('precompiled/ext/precompiled/extconf.rb')}}
-      - env:
-          DOCKER_IMAGE: "ghcr.io/rake-compiler/rake-compiler-dock-image:${{needs.rcd_image_version.outputs.rcd_image_version}}-mri-${{matrix.plat}}"
-        run: |
-          docker run --rm -v "$(pwd)/precompiled:/precompiled" -w /precompiled \
-            ${DOCKER_IMAGE} \
-            ./bin/test-gem-build gems ${{matrix.plat}}
+      - run: |
+          docker run --rm -v $PWD/precompiled:/precompiled -w /precompiled \
+            ghcr.io/rake-compiler/rake-compiler-dock-image:${{ needs.rcd_image_version.outputs.rcd_image_version }}-mri-${{ matrix.platform }} \
+            ./bin/test-gem-build gems ${{ matrix.platform }}
       - uses: actions/upload-artifact@v2
         with:
-          name: "cruby-${{matrix.plat}}-gem"
+          name: "cruby-${{ matrix.platform }}-gem"
           path: precompiled/gems
           retention-days: 1
 
-  cruby-x86_64-linux-install:
+  cruby-linux-install:
     needs: ["cruby-native-package"]
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        platform:
+          - "aarch64-linux"
+          - "arm-linux"
+          - "x86-linux"
+          - "x86_64-linux"
+        ruby: ["3.0", "3.1", "3.2", "3.3"]
+        include:
+          # declare docker platform for each platform
+          - { platform: aarch64-linux, docker_platform: "--platform=linux/arm64/v8" }
+          - { platform: arm-linux, docker_platform: "--platform=linux/arm/v7" }
+          - { platform: x86-linux, docker_platform: "--platform=linux/386" }
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: "${{matrix.ruby}}"
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v2
         with:
-          name: cruby-x86_64-linux-gem
-          path: precompiled/gems
-      - run: ./bin/test-gem-install gems
-        working-directory: precompiled
-
-  cruby-x86-linux-install:
-    needs: ["cruby-native-package"]
-    strategy:
-      fail-fast: false
-      matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
-        with:
-          name: cruby-x86-linux-gem
+          name: cruby-${{ matrix.platform }}-gem
           path: precompiled/gems
       - run: |
           docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-          docker run --rm -v "$(pwd)/precompiled:/precompiled" -w /precompiled \
-            --platform=linux/386 \
-            ruby:${{matrix.ruby}} \
-            ./bin/test-gem-install ./gems
-
-  cruby-aarch64-linux-install:
-    needs: ["cruby-native-package"]
-    strategy:
-      fail-fast: false
-      matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
-        with:
-          name: cruby-aarch64-linux-gem
-          path: precompiled/gems
-      - run: |
-          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-          docker run --rm -v "$(pwd)/precompiled:/precompiled" -w /precompiled \
-            --platform=linux/arm64/v8 \
-            ruby:${{matrix.ruby}} \
-            ./bin/test-gem-install ./gems
-
-  cruby-arm-linux-install:
-    needs: ["cruby-native-package"]
-    strategy:
-      fail-fast: false
-      matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
-        with:
-          name: cruby-arm-linux-gem
-          path: precompiled/gems
-      - run: |
-          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-          docker run --rm -v "$(pwd)/precompiled:/precompiled" -w /precompiled \
-            --platform=linux/arm/v7 \
-            ruby:${{matrix.ruby}} \
-            ./bin/test-gem-install ./gems
+          docker run --rm -v $PWD/precompiled:/precompiled -w /precompiled \
+            ${{ matrix.docker_platform }} ruby:${{ matrix.ruby }} \
+            ./bin/test-gem-install gems
 
   cruby-x86_64-musl-install:
     needs: ["cruby-native-package"]
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["3.0", "3.1", "3.2", "3.3"]
     runs-on: ubuntu-latest
     container:
       image: "ruby:${{matrix.ruby}}-alpine"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v2
         with:
           name: cruby-x86_64-linux-gem
@@ -310,10 +182,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["3.0", "3.1", "3.2", "3.3"]
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "${{matrix.ruby}}"
@@ -324,19 +196,19 @@ jobs:
       - run: ./bin/test-gem-install gems
         working-directory: precompiled
 
-## arm64-darwin installation testing is omitted until github actions supports it
-#  cruby-arm64-darwin-install:
-#    ...
+  ## arm64-darwin installation testing is omitted until github actions supports it
+  #  cruby-arm64-darwin-install:
+  #    ...
 
   cruby-x64-mingw32-install:
     needs: ["cruby-native-package"]
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0"]
+        ruby: ["3.0"]
     runs-on: windows-2019
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "${{matrix.ruby}}"
@@ -352,11 +224,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1", "3.2"]
+        ruby: ["3.1", "3.2", "3.3"]
     runs-on: windows-2022
     steps:
-      - uses: actions/checkout@v2
-      - uses: MSP-Greg/setup-ruby-pkgs@v1
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "${{matrix.ruby}}"
       - uses: actions/download-artifact@v2

--- a/.github/workflows/system.yml
+++ b/.github/workflows/system.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["3.0", "3.1", "3.2", "3.3", "head"]
         runs-on: ["ubuntu-latest", "macos-latest", "windows-latest"]
     runs-on: ${{matrix.runs-on}}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Added
 
-- `precompiled` gem now supports Ruby 3.2 and drops support for Ruby 2.6
+- `precompiled` gem now supports Ruby 3.2 and 3.3, and drops support for Ruby 2.6 and 2.7
+- The `extconf.rb` file in `packaged_tarball` and `precompiled` now use a `ExtConf` module pattern for encapsulation.
 
 
 ## 0.4.0 / 2022-05-19

--- a/precompiled/Gemfile
+++ b/precompiled/Gemfile
@@ -8,6 +8,6 @@ gemspec
 gem "rake", "~> 13.0"
 
 gem "rake-compiler"
-gem "rake-compiler-dock", "~> 1.3.0"
+gem "rake-compiler-dock", "1.5.0.rc1"
 
 gem "minitest", "~> 5.0"

--- a/precompiled/README.md
+++ b/precompiled/README.md
@@ -26,7 +26,7 @@ This is really powerful stuff, and once we assume that we can cross-compile reli
 First, we need to add some features to our `Rake::ExtensionTask` in `Rakefile`:
 
 ``` ruby
-cross_rubies = ["3.2.0", "3.1.0", "3.0.0", "2.7.0"]
+cross_rubies = ["3.3.0", "3.2.0", "3.1.0", "3.0.0"]
 cross_platforms = [
   "x64-mingw32",
   "x64-mingw-ucrt",
@@ -131,13 +131,13 @@ We have one more small change we'll need to make to how the extension is require
 lib
 └── rcee
     ├── precompiled
-    │   ├── 2.7
-    │   │   └── precompiled.so
     │   ├── 3.0
     │   │   └── precompiled.so
     │   ├── 3.1
     │   │   └── precompiled.so
     │   ├── 3.2
+    │   │   └── precompiled.so
+    │   ├── 3.3
     │   │   └── precompiled.so
     │   └── version.rb
     └── precompiled.rb

--- a/precompiled/Rakefile
+++ b/precompiled/Rakefile
@@ -6,7 +6,7 @@ require "rake/testtask"
 require "rake/extensiontask"
 require "rake_compiler_dock"
 
-cross_rubies = ["3.2.0", "3.1.0", "3.0.0", "2.7.0"]
+cross_rubies = ["3.3.0", "3.2.0", "3.1.0", "3.0.0"]
 cross_platforms = [
   "aarch64-linux",
   "arm-linux",

--- a/precompiled/rcee_precompiled.gemspec
+++ b/precompiled/rcee_precompiled.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.summary       = "Example gem demonstrating a basic C extension."
   spec.description   = "Part of a project to explain how Ruby C extensions work."
   spec.homepage      = "https://github.com/flavorjones/ruby-c-extensions-explained"
-  spec.required_ruby_version = ">= 2.7.0"
+  spec.required_ruby_version = ">= 3.0.0"
   spec.license = "MIT"
 
   # Specify which files should be added to the gem when it is released.


### PR DESCRIPTION
- update to rake-compiler-dock 1.5.0
- precompiled drops 2.7 support
- better linux matrix for testing precompiled