### PR TITLE
ci: add arm64-darwin precompiled coverage

### DIFF
--- a/.github/workflows/precompiled.yml
+++ b/.github/workflows/precompiled.yml
@@ -109,7 +109,7 @@ jobs:
           - "aarch64-linux-musl"
           - "arm-linux-gnu"
           - "arm-linux-musl"
-          - "arm64-darwin" # github actions does not support this runtime, but let's build anyway
+          - "arm64-darwin"
           - "x64-mingw-ucrt"
           - "x64-mingw32"
           - "x86-linux-gnu"
@@ -185,7 +185,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ["3.0", "3.1", "3.2", "3.3"]
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
@@ -198,9 +198,24 @@ jobs:
       - run: ./bin/test-gem-install gems
         working-directory: precompiled
 
-  ## arm64-darwin installation testing is omitted until github actions supports it
-  #  cruby-arm64-darwin-install:
-  #    ...
+  cruby-arm64-darwin-install:
+    needs: ["cruby-native-package"]
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["3.0", "3.1", "3.2", "3.3"]
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "${{matrix.ruby}}"
+      - uses: actions/download-artifact@v4
+        with:
+          name: cruby-arm64-darwin-gem
+          path: precompiled/gems
+      - run: ./bin/test-gem-install gems
+        working-directory: precompiled
 
   cruby-x64-mingw32-install:
     needs: ["cruby-native-package"]


### PR DESCRIPTION
Note that we need to pin to `macos-13` for x86_64, and `macos-14` for arm64. For more information, see:

https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories