### PR TITLE
fix: patch automake files for arm64-apple

### DIFF
--- a/.github/workflows/packaged_tarball.yml
+++ b/.github/workflows/packaged_tarball.yml
@@ -27,6 +27,11 @@ jobs:
         runs-on: ["ubuntu-latest", "macos-latest", "windows-latest"]
     runs-on: ${{matrix.runs-on}}
     steps:
+      - name: configure git crlf
+        if: matrix.runs-on == 'windows-latest'
+        run: |
+          git config --system core.autocrlf false
+          git config --system core.eol lf
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:

--- a/packaged_tarball/ext/packaged_tarball/extconf.rb
+++ b/packaged_tarball/ext/packaged_tarball/extconf.rb
@@ -41,6 +41,7 @@ module RCEE
               url: "https://github.com/yaml/libyaml/releases/download/0.2.5/yaml-0.2.5.tar.gz",
               sha256: "c642ae9b75fee120b2d96c712538bd2cf283228d2337df2cf2988e3c02678ef4"
             }]
+            recipe.patch_files = Dir[File.join(PACKAGE_ROOT_DIR, "patches", "libyaml", "*.patch")].sort
             recipe.target = File.join(PACKAGE_ROOT_DIR, "ports")
           end
         end

--- a/packaged_tarball/ext/packaged_tarball/extconf.rb
+++ b/packaged_tarball/ext/packaged_tarball/extconf.rb
@@ -26,7 +26,7 @@ module RCEE
           pkg_config(File.join(recipe.path, "lib", "pkgconfig", "yaml-0.1.pc"))
 
           # assert that we can build against the packaged libyaml
-          unless have_library("yaml", "yaml_get_version", "yaml.h")
+          unless find_header("yaml.h") && have_library("yaml", "yaml_get_version", "yaml.h")
             abort("\nERROR: *** could not find libyaml development environment ***\n\n")
           end
         end

--- a/packaged_tarball/patches/libyaml/0001-update-automake-files.patch
+++ b/packaged_tarball/patches/libyaml/0001-update-automake-files.patch
@@ -1,0 +1,5383 @@
+Update config.guess and config.sub to the latest from automake to support modern architectures.
+
+--- a/config/config.guess
++++ b/config/config.guess
+@@ -1,12 +1,14 @@
+ #! /bin/sh
+ # Attempt to guess a canonical system name.
+-#   Copyright 1992-2018 Free Software Foundation, Inc.
++#   Copyright 1992-2024 Free Software Foundation, Inc.
+ 
+-timestamp='2018-02-24'
++# shellcheck disable=SC2006,SC2268 # see below for rationale
++
++timestamp='2024-01-01'
+ 
+ # This file is free software; you can redistribute it and/or modify it
+ # under the terms of the GNU General Public License as published by
+-# the Free Software Foundation; either version 3 of the License, or
++# the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful, but
+@@ -27,17 +29,25 @@
+ # Originally written by Per Bothner; maintained since 2000 by Ben Elliston.
+ #
+ # You can get the latest version of this script from:
+-# https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess
++# https://git.savannah.gnu.org/cgit/config.git/plain/config.guess
+ #
+ # Please send patches to <config-patches@gnu.org>.
+ 
+ 
++# The "shellcheck disable" line above the timestamp inhibits complaints
++# about features and limitations of the classic Bourne shell that were
++# superseded or lifted in POSIX.  However, this script identifies a wide
++# variety of pre-POSIX systems that do not have POSIX shells at all, and
++# even some reasonably current systems (Solaris 10 as case-in-point) still
++# have a pre-POSIX /bin/sh.
++
++
+ me=`echo "$0" | sed -e 's,.*/,,'`
+ 
+ usage="\
+ Usage: $0 [OPTION]
+ 
+-Output the configuration name of the system \`$me' is run on.
++Output the configuration name of the system '$me' is run on.
+ 
+ Options:
+   -h, --help         print this help, then exit
+@@ -50,13 +60,13 @@
+ GNU config.guess ($timestamp)
+ 
+ Originally written by Per Bothner.
+-Copyright 1992-2018 Free Software Foundation, Inc.
++Copyright 1992-2024 Free Software Foundation, Inc.
+ 
+ This is free software; see the source for copying conditions.  There is NO
+ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."
+ 
+ help="
+-Try \`$me --help' for more information."
++Try '$me --help' for more information."
+ 
+ # Parse command line
+ while test $# -gt 0 ; do
+@@ -84,85 +94,109 @@
+   exit 1
+ fi
+ 
+-trap 'exit 1' 1 2 15
++# Just in case it came from the environment.
++GUESS=
+ 
+ # CC_FOR_BUILD -- compiler used by this script. Note that the use of a
+ # compiler to aid in system detection is discouraged as it requires
+ # temporary files to be created and, as you can see below, it is a
+ # headache to deal with in a portable fashion.
+ 
+-# Historically, `CC_FOR_BUILD' used to be named `HOST_CC'. We still
+-# use `HOST_CC' if defined, but it is deprecated.
++# Historically, 'CC_FOR_BUILD' used to be named 'HOST_CC'. We still
++# use 'HOST_CC' if defined, but it is deprecated.
+ 
+ # Portable tmp directory creation inspired by the Autoconf team.
+ 
+-set_cc_for_build='
+-trap "exitcode=\$?; (rm -f \$tmpfiles 2>/dev/null; rmdir \$tmp 2>/dev/null) && exit \$exitcode" 0 ;
+-trap "rm -f \$tmpfiles 2>/dev/null; rmdir \$tmp 2>/dev/null; exit 1" 1 2 13 15 ;
+-: ${TMPDIR=/tmp} ;
+- { tmp=`(umask 077 && mktemp -d "$TMPDIR/cgXXXXXX") 2>/dev/null` && test -n "$tmp" && test -d "$tmp" ; } ||
+- { test -n "$RANDOM" && tmp=$TMPDIR/cg$$-$RANDOM && (umask 077 && mkdir $tmp) ; } ||
+- { tmp=$TMPDIR/cg-$$ && (umask 077 && mkdir $tmp) && echo "Warning: creating insecure temp directory" >&2 ; } ||
+- { echo "$me: cannot create a temporary directory in $TMPDIR" >&2 ; exit 1 ; } ;
+-dummy=$tmp/dummy ;
+-tmpfiles="$dummy.c $dummy.o $dummy.rel $dummy" ;
+-case $CC_FOR_BUILD,$HOST_CC,$CC in
+- ,,)    echo "int x;" > "$dummy.c" ;
+-	for c in cc gcc c89 c99 ; do
+-	  if ($c -c -o "$dummy.o" "$dummy.c") >/dev/null 2>&1 ; then
+-	     CC_FOR_BUILD="$c"; break ;
+-	  fi ;
+-	done ;
+-	if test x"$CC_FOR_BUILD" = x ; then
+-	  CC_FOR_BUILD=no_compiler_found ;
+-	fi
+-	;;
+- ,,*)   CC_FOR_BUILD=$CC ;;
+- ,*,*)  CC_FOR_BUILD=$HOST_CC ;;
+-esac ; set_cc_for_build= ;'
++tmp=
++# shellcheck disable=SC2172
++trap 'test -z "$tmp" || rm -fr "$tmp"' 0 1 2 13 15
++
++set_cc_for_build() {
++    # prevent multiple calls if $tmp is already set
++    test "$tmp" && return 0
++    : "${TMPDIR=/tmp}"
++    # shellcheck disable=SC2039,SC3028
++    { tmp=`(umask 077 && mktemp -d "$TMPDIR/cgXXXXXX") 2>/dev/null` && test -n "$tmp" && test -d "$tmp" ; } ||
++	{ test -n "$RANDOM" && tmp=$TMPDIR/cg$$-$RANDOM && (umask 077 && mkdir "$tmp" 2>/dev/null) ; } ||
++	{ tmp=$TMPDIR/cg-$$ && (umask 077 && mkdir "$tmp" 2>/dev/null) && echo "Warning: creating insecure temp directory" >&2 ; } ||
++	{ echo "$me: cannot create a temporary directory in $TMPDIR" >&2 ; exit 1 ; }
++    dummy=$tmp/dummy
++    case ${CC_FOR_BUILD-},${HOST_CC-},${CC-} in
++	,,)    echo "int x;" > "$dummy.c"
++	       for driver in cc gcc c89 c99 ; do
++		   if ($driver -c -o "$dummy.o" "$dummy.c") >/dev/null 2>&1 ; then
++		       CC_FOR_BUILD=$driver
++		       break
++		   fi
++	       done
++	       if test x"$CC_FOR_BUILD" = x ; then
++		   CC_FOR_BUILD=no_compiler_found
++	       fi
++	       ;;
++	,,*)   CC_FOR_BUILD=$CC ;;
++	,*,*)  CC_FOR_BUILD=$HOST_CC ;;
++    esac
++}
+ 
+ # This is needed to find uname on a Pyramid OSx when run in the BSD universe.
+ # (ghazi@noc.rutgers.edu 1994-08-24)
+-if (test -f /.attbin/uname) >/dev/null 2>&1 ; then
++if test -f /.attbin/uname ; then
+ 	PATH=$PATH:/.attbin ; export PATH
+ fi
+ 
+ UNAME_MACHINE=`(uname -m) 2>/dev/null` || UNAME_MACHINE=unknown
+ UNAME_RELEASE=`(uname -r) 2>/dev/null` || UNAME_RELEASE=unknown
+-UNAME_SYSTEM=`(uname -s) 2>/dev/null`  || UNAME_SYSTEM=unknown
++UNAME_SYSTEM=`(uname -s) 2>/dev/null` || UNAME_SYSTEM=unknown
+ UNAME_VERSION=`(uname -v) 2>/dev/null` || UNAME_VERSION=unknown
+ 
+-case "$UNAME_SYSTEM" in
++case $UNAME_SYSTEM in
+ Linux|GNU|GNU/*)
+-	# If the system lacks a compiler, then just pick glibc.
+-	# We could probably try harder.
+-	LIBC=gnu
++	LIBC=unknown
+ 
+-	eval "$set_cc_for_build"
++	set_cc_for_build
+ 	cat <<-EOF > "$dummy.c"
++	#if defined(__ANDROID__)
++	LIBC=android
++	#else
+ 	#include <features.h>
+ 	#if defined(__UCLIBC__)
+ 	LIBC=uclibc
+ 	#elif defined(__dietlibc__)
+ 	LIBC=dietlibc
+-	#else
++	#elif defined(__GLIBC__)
+ 	LIBC=gnu
++	#elif defined(__LLVM_LIBC__)
++	LIBC=llvm
++	#else
++	#include <stdarg.h>
++	/* First heuristic to detect musl libc.  */
++	#ifdef __DEFINED_va_list
++	LIBC=musl
++	#endif
++	#endif
+ 	#endif
+ 	EOF
+-	eval "`$CC_FOR_BUILD -E "$dummy.c" 2>/dev/null | grep '^LIBC' | sed 's, ,,g'`"
++	cc_set_libc=`$CC_FOR_BUILD -E "$dummy.c" 2>/dev/null | grep '^LIBC' | sed 's, ,,g'`
++	eval "$cc_set_libc"
+ 
+-	# If ldd exists, use it to detect musl libc.
+-	if command -v ldd >/dev/null && \
+-		ldd --version 2>&1 | grep -q ^musl
+-	then
+-	    LIBC=musl
++	# Second heuristic to detect musl libc.
++	if [ "$LIBC" = unknown ] &&
++	   command -v ldd >/dev/null &&
++	   ldd --version 2>&1 | grep -q ^musl; then
++		LIBC=musl
++	fi
++
++	# If the system lacks a compiler, then just pick glibc.
++	# We could probably try harder.
++	if [ "$LIBC" = unknown ]; then
++		LIBC=gnu
+ 	fi
+ 	;;
+ esac
+ 
+ # Note: order is significant - the case branches are not exclusive.
+ 
+-case "$UNAME_MACHINE:$UNAME_SYSTEM:$UNAME_RELEASE:$UNAME_VERSION" in
++case $UNAME_MACHINE:$UNAME_SYSTEM:$UNAME_RELEASE:$UNAME_VERSION in
+     *:NetBSD:*:*)
+ 	# NetBSD (nbsd) targets should (where applicable) match one or
+ 	# more of the tuples: *-*-netbsdelf*, *-*-netbsdaout*,
+@@ -174,12 +208,12 @@
+ 	#
+ 	# Note: NetBSD doesn't particularly care about the vendor
+ 	# portion of the name.  We always set it to "unknown".
+-	sysctl="sysctl -n hw.machine_arch"
+ 	UNAME_MACHINE_ARCH=`(uname -p 2>/dev/null || \
+-	    "/sbin/$sysctl" 2>/dev/null || \
+-	    "/usr/sbin/$sysctl" 2>/dev/null || \
++	    /sbin/sysctl -n hw.machine_arch 2>/dev/null || \
++	    /usr/sbin/sysctl -n hw.machine_arch 2>/dev/null || \
+ 	    echo unknown)`
+-	case "$UNAME_MACHINE_ARCH" in
++	case $UNAME_MACHINE_ARCH in
++	    aarch64eb) machine=aarch64_be-unknown ;;
+ 	    armeb) machine=armeb-unknown ;;
+ 	    arm*) machine=arm-unknown ;;
+ 	    sh3el) machine=shl-unknown ;;
+@@ -188,18 +222,18 @@
+ 	    earmv*)
+ 		arch=`echo "$UNAME_MACHINE_ARCH" | sed -e 's,^e\(armv[0-9]\).*$,\1,'`
+ 		endian=`echo "$UNAME_MACHINE_ARCH" | sed -ne 's,^.*\(eb\)$,\1,p'`
+-		machine="${arch}${endian}"-unknown
++		machine=${arch}${endian}-unknown
+ 		;;
+-	    *) machine="$UNAME_MACHINE_ARCH"-unknown ;;
++	    *) machine=$UNAME_MACHINE_ARCH-unknown ;;
+ 	esac
+ 	# The Operating System including object format, if it has switched
+ 	# to ELF recently (or will in the future) and ABI.
+-	case "$UNAME_MACHINE_ARCH" in
++	case $UNAME_MACHINE_ARCH in
+ 	    earm*)
+ 		os=netbsdelf
+ 		;;
+ 	    arm*|i386|m68k|ns32k|sh3*|sparc|vax)
+-		eval "$set_cc_for_build"
++		set_cc_for_build
+ 		if echo __ELF__ | $CC_FOR_BUILD -E - 2>/dev/null \
+ 			| grep -q __ELF__
+ 		then
+@@ -215,7 +249,7 @@
+ 		;;
+ 	esac
+ 	# Determine ABI tags.
+-	case "$UNAME_MACHINE_ARCH" in
++	case $UNAME_MACHINE_ARCH in
+ 	    earm*)
+ 		expr='s/^earmv[0-9]/-eabi/;s/eb$//'
+ 		abi=`echo "$UNAME_MACHINE_ARCH" | sed -e "$expr"`
+@@ -226,7 +260,7 @@
+ 	# thus, need a distinct triplet. However, they do not need
+ 	# kernel version information, so it can be replaced with a
+ 	# suitable tag, in the style of linux-gnu.
+-	case "$UNAME_VERSION" in
++	case $UNAME_VERSION in
+ 	    Debian*)
+ 		release='-gnu'
+ 		;;
+@@ -237,45 +271,57 @@
+ 	# Since CPU_TYPE-MANUFACTURER-KERNEL-OPERATING_SYSTEM:
+ 	# contains redundant information, the shorter form:
+ 	# CPU_TYPE-MANUFACTURER-OPERATING_SYSTEM is used.
+-	echo "$machine-${os}${release}${abi}"
+-	exit ;;
++	GUESS=$machine-${os}${release}${abi-}
++	;;
+     *:Bitrig:*:*)
+ 	UNAME_MACHINE_ARCH=`arch | sed 's/Bitrig.//'`
+-	echo "$UNAME_MACHINE_ARCH"-unknown-bitrig"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=$UNAME_MACHINE_ARCH-unknown-bitrig$UNAME_RELEASE
++	;;
+     *:OpenBSD:*:*)
+ 	UNAME_MACHINE_ARCH=`arch | sed 's/OpenBSD.//'`
+-	echo "$UNAME_MACHINE_ARCH"-unknown-openbsd"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=$UNAME_MACHINE_ARCH-unknown-openbsd$UNAME_RELEASE
++	;;
++    *:SecBSD:*:*)
++	UNAME_MACHINE_ARCH=`arch | sed 's/SecBSD.//'`
++	GUESS=$UNAME_MACHINE_ARCH-unknown-secbsd$UNAME_RELEASE
++	;;
+     *:LibertyBSD:*:*)
+ 	UNAME_MACHINE_ARCH=`arch | sed 's/^.*BSD\.//'`
+-	echo "$UNAME_MACHINE_ARCH"-unknown-libertybsd"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=$UNAME_MACHINE_ARCH-unknown-libertybsd$UNAME_RELEASE
++	;;
+     *:MidnightBSD:*:*)
+-	echo "$UNAME_MACHINE"-unknown-midnightbsd"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=$UNAME_MACHINE-unknown-midnightbsd$UNAME_RELEASE
++	;;
+     *:ekkoBSD:*:*)
+-	echo "$UNAME_MACHINE"-unknown-ekkobsd"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=$UNAME_MACHINE-unknown-ekkobsd$UNAME_RELEASE
++	;;
+     *:SolidBSD:*:*)
+-	echo "$UNAME_MACHINE"-unknown-solidbsd"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=$UNAME_MACHINE-unknown-solidbsd$UNAME_RELEASE
++	;;
++    *:OS108:*:*)
++	GUESS=$UNAME_MACHINE-unknown-os108_$UNAME_RELEASE
++	;;
+     macppc:MirBSD:*:*)
+-	echo powerpc-unknown-mirbsd"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=powerpc-unknown-mirbsd$UNAME_RELEASE
++	;;
+     *:MirBSD:*:*)
+-	echo "$UNAME_MACHINE"-unknown-mirbsd"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=$UNAME_MACHINE-unknown-mirbsd$UNAME_RELEASE
++	;;
+     *:Sortix:*:*)
+-	echo "$UNAME_MACHINE"-unknown-sortix
+-	exit ;;
++	GUESS=$UNAME_MACHINE-unknown-sortix
++	;;
++    *:Twizzler:*:*)
++	GUESS=$UNAME_MACHINE-unknown-twizzler
++	;;
+     *:Redox:*:*)
+-	echo "$UNAME_MACHINE"-unknown-redox
+-	exit ;;
++	GUESS=$UNAME_MACHINE-unknown-redox
++	;;
+     mips:OSF1:*.*)
+-        echo mips-dec-osf1
+-        exit ;;
++	GUESS=mips-dec-osf1
++	;;
+     alpha:OSF1:*:*)
++	# Reset EXIT trap before exiting to avoid spurious non-zero exit code.
++	trap '' 0
+ 	case $UNAME_RELEASE in
+ 	*4.0)
+ 		UNAME_RELEASE=`/usr/sbin/sizer -v | awk '{print $3}'`
+@@ -289,7 +335,7 @@
+ 	# covers most systems running today.  This code pipes the CPU
+ 	# types through head -n 1, so we only detect the type of CPU 0.
+ 	ALPHA_CPU_TYPE=`/usr/sbin/psrinfo -v | sed -n -e 's/^  The alpha \(.*\) processor.*$/\1/p' | head -n 1`
+-	case "$ALPHA_CPU_TYPE" in
++	case $ALPHA_CPU_TYPE in
+ 	    "EV4 (21064)")
+ 		UNAME_MACHINE=alpha ;;
+ 	    "EV4.5 (21064)")
+@@ -326,117 +372,121 @@
+ 	# A Tn.n version is a released field test version.
+ 	# A Xn.n version is an unreleased experimental baselevel.
+ 	# 1.2 uses "1.2" for uname -r.
+-	echo "$UNAME_MACHINE"-dec-osf"`echo "$UNAME_RELEASE" | sed -e 's/^[PVTX]//' | tr ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz`"
+-	# Reset EXIT trap before exiting to avoid spurious non-zero exit code.
+-	exitcode=$?
+-	trap '' 0
+-	exit $exitcode ;;
++	OSF_REL=`echo "$UNAME_RELEASE" | sed -e 's/^[PVTX]//' | tr ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz`
++	GUESS=$UNAME_MACHINE-dec-osf$OSF_REL
++	;;
+     Amiga*:UNIX_System_V:4.0:*)
+-	echo m68k-unknown-sysv4
+-	exit ;;
++	GUESS=m68k-unknown-sysv4
++	;;
+     *:[Aa]miga[Oo][Ss]:*:*)
+-	echo "$UNAME_MACHINE"-unknown-amigaos
+-	exit ;;
++	GUESS=$UNAME_MACHINE-unknown-amigaos
++	;;
+     *:[Mm]orph[Oo][Ss]:*:*)
+-	echo "$UNAME_MACHINE"-unknown-morphos
+-	exit ;;
++	GUESS=$UNAME_MACHINE-unknown-morphos
++	;;
+     *:OS/390:*:*)
+-	echo i370-ibm-openedition
+-	exit ;;
++	GUESS=i370-ibm-openedition
++	;;
+     *:z/VM:*:*)
+-	echo s390-ibm-zvmoe
+-	exit ;;
++	GUESS=s390-ibm-zvmoe
++	;;
+     *:OS400:*:*)
+-	echo powerpc-ibm-os400
+-	exit ;;
++	GUESS=powerpc-ibm-os400
++	;;
+     arm:RISC*:1.[012]*:*|arm:riscix:1.[012]*:*)
+-	echo arm-acorn-riscix"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=arm-acorn-riscix$UNAME_RELEASE
++	;;
+     arm*:riscos:*:*|arm*:RISCOS:*:*)
+-	echo arm-unknown-riscos
+-	exit ;;
++	GUESS=arm-unknown-riscos
++	;;
+     SR2?01:HI-UX/MPP:*:* | SR8000:HI-UX/MPP:*:*)
+-	echo hppa1.1-hitachi-hiuxmpp
+-	exit ;;
++	GUESS=hppa1.1-hitachi-hiuxmpp
++	;;
+     Pyramid*:OSx*:*:* | MIS*:OSx*:*:* | MIS*:SMP_DC-OSx*:*:*)
+ 	# akee@wpdis03.wpafb.af.mil (Earle F. Ake) contributed MIS and NILE.
+-	if test "`(/bin/universe) 2>/dev/null`" = att ; then
+-		echo pyramid-pyramid-sysv3
+-	else
+-		echo pyramid-pyramid-bsd
+-	fi
+-	exit ;;
++	case `(/bin/universe) 2>/dev/null` in
++	    att) GUESS=pyramid-pyramid-sysv3 ;;
++	    *)   GUESS=pyramid-pyramid-bsd   ;;
++	esac
++	;;
+     NILE*:*:*:dcosx)
+-	echo pyramid-pyramid-svr4
+-	exit ;;
++	GUESS=pyramid-pyramid-svr4
++	;;
+     DRS?6000:unix:4.0:6*)
+-	echo sparc-icl-nx6
+-	exit ;;
++	GUESS=sparc-icl-nx6
++	;;
+     DRS?6000:UNIX_SV:4.2*:7* | DRS?6000:isis:4.2*:7*)
+ 	case `/usr/bin/uname -p` in
+-	    sparc) echo sparc-icl-nx7; exit ;;
+-	esac ;;
++	    sparc) GUESS=sparc-icl-nx7 ;;
++	esac
++	;;
+     s390x:SunOS:*:*)
+-	echo "$UNAME_MACHINE"-ibm-solaris2"`echo "$UNAME_RELEASE" | sed -e 's/[^.]*//'`"
+-	exit ;;
++	SUN_REL=`echo "$UNAME_RELEASE" | sed -e 's/[^.]*//'`
++	GUESS=$UNAME_MACHINE-ibm-solaris2$SUN_REL
++	;;
+     sun4H:SunOS:5.*:*)
+-	echo sparc-hal-solaris2"`echo "$UNAME_RELEASE"|sed -e 's/[^.]*//'`"
+-	exit ;;
++	SUN_REL=`echo "$UNAME_RELEASE" | sed -e 's/[^.]*//'`
++	GUESS=sparc-hal-solaris2$SUN_REL
++	;;
+     sun4*:SunOS:5.*:* | tadpole*:SunOS:5.*:*)
+-	echo sparc-sun-solaris2"`echo "$UNAME_RELEASE" | sed -e 's/[^.]*//'`"
+-	exit ;;
++	SUN_REL=`echo "$UNAME_RELEASE" | sed -e 's/[^.]*//'`
++	GUESS=sparc-sun-solaris2$SUN_REL
++	;;
+     i86pc:AuroraUX:5.*:* | i86xen:AuroraUX:5.*:*)
+-	echo i386-pc-auroraux"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=i386-pc-auroraux$UNAME_RELEASE
++	;;
+     i86pc:SunOS:5.*:* | i86xen:SunOS:5.*:*)
+-	eval "$set_cc_for_build"
++	set_cc_for_build
+ 	SUN_ARCH=i386
+ 	# If there is a compiler, see if it is configured for 64-bit objects.
+ 	# Note that the Sun cc does not turn __LP64__ into 1 like gcc does.
+ 	# This test works for both compilers.
+-	if [ "$CC_FOR_BUILD" != no_compiler_found ]; then
++	if test "$CC_FOR_BUILD" != no_compiler_found; then
+ 	    if (echo '#ifdef __amd64'; echo IS_64BIT_ARCH; echo '#endif') | \
+-		(CCOPTS="" $CC_FOR_BUILD -E - 2>/dev/null) | \
++		(CCOPTS="" $CC_FOR_BUILD -m64 -E - 2>/dev/null) | \
+ 		grep IS_64BIT_ARCH >/dev/null
+ 	    then
+ 		SUN_ARCH=x86_64
+ 	    fi
+ 	fi
+-	echo "$SUN_ARCH"-pc-solaris2"`echo "$UNAME_RELEASE"|sed -e 's/[^.]*//'`"
+-	exit ;;
++	SUN_REL=`echo "$UNAME_RELEASE" | sed -e 's/[^.]*//'`
++	GUESS=$SUN_ARCH-pc-solaris2$SUN_REL
++	;;
+     sun4*:SunOS:6*:*)
+ 	# According to config.sub, this is the proper way to canonicalize
+ 	# SunOS6.  Hard to guess exactly what SunOS6 will be like, but
+ 	# it's likely to be more like Solaris than SunOS4.
+-	echo sparc-sun-solaris3"`echo "$UNAME_RELEASE"|sed -e 's/[^.]*//'`"
+-	exit ;;
++	SUN_REL=`echo "$UNAME_RELEASE" | sed -e 's/[^.]*//'`
++	GUESS=sparc-sun-solaris3$SUN_REL
++	;;
+     sun4*:SunOS:*:*)
+-	case "`/usr/bin/arch -k`" in
++	case `/usr/bin/arch -k` in
+ 	    Series*|S4*)
+ 		UNAME_RELEASE=`uname -v`
+ 		;;
+ 	esac
+-	# Japanese Language versions have a version number like `4.1.3-JL'.
+-	echo sparc-sun-sunos"`echo "$UNAME_RELEASE"|sed -e 's/-/_/'`"
+-	exit ;;
++	# Japanese Language versions have a version number like '4.1.3-JL'.
++	SUN_REL=`echo "$UNAME_RELEASE" | sed -e 's/-/_/'`
++	GUESS=sparc-sun-sunos$SUN_REL
++	;;
+     sun3*:SunOS:*:*)
+-	echo m68k-sun-sunos"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=m68k-sun-sunos$UNAME_RELEASE
++	;;
+     sun*:*:4.2BSD:*)
+ 	UNAME_RELEASE=`(sed 1q /etc/motd | awk '{print substr($5,1,3)}') 2>/dev/null`
+ 	test "x$UNAME_RELEASE" = x && UNAME_RELEASE=3
+-	case "`/bin/arch`" in
++	case `/bin/arch` in
+ 	    sun3)
+-		echo m68k-sun-sunos"$UNAME_RELEASE"
++		GUESS=m68k-sun-sunos$UNAME_RELEASE
+ 		;;
+ 	    sun4)
+-		echo sparc-sun-sunos"$UNAME_RELEASE"
++		GUESS=sparc-sun-sunos$UNAME_RELEASE
+ 		;;
+ 	esac
+-	exit ;;
++	;;
+     aushp:SunOS:*:*)
+-	echo sparc-auspex-sunos"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=sparc-auspex-sunos$UNAME_RELEASE
++	;;
+     # The situation for MiNT is a little confusing.  The machine name
+     # can be virtually everything (everything which is not
+     # "atarist" or "atariste" at least should have a processor
+@@ -446,43 +496,43 @@
+     # MiNT.  But MiNT is downward compatible to TOS, so this should
+     # be no problem.
+     atarist[e]:*MiNT:*:* | atarist[e]:*mint:*:* | atarist[e]:*TOS:*:*)
+-	echo m68k-atari-mint"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=m68k-atari-mint$UNAME_RELEASE
++	;;
+     atari*:*MiNT:*:* | atari*:*mint:*:* | atarist[e]:*TOS:*:*)
+-	echo m68k-atari-mint"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=m68k-atari-mint$UNAME_RELEASE
++	;;
+     *falcon*:*MiNT:*:* | *falcon*:*mint:*:* | *falcon*:*TOS:*:*)
+-	echo m68k-atari-mint"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=m68k-atari-mint$UNAME_RELEASE
++	;;
+     milan*:*MiNT:*:* | milan*:*mint:*:* | *milan*:*TOS:*:*)
+-	echo m68k-milan-mint"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=m68k-milan-mint$UNAME_RELEASE
++	;;
+     hades*:*MiNT:*:* | hades*:*mint:*:* | *hades*:*TOS:*:*)
+-	echo m68k-hades-mint"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=m68k-hades-mint$UNAME_RELEASE
++	;;
+     *:*MiNT:*:* | *:*mint:*:* | *:*TOS:*:*)
+-	echo m68k-unknown-mint"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=m68k-unknown-mint$UNAME_RELEASE
++	;;
+     m68k:machten:*:*)
+-	echo m68k-apple-machten"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=m68k-apple-machten$UNAME_RELEASE
++	;;
+     powerpc:machten:*:*)
+-	echo powerpc-apple-machten"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=powerpc-apple-machten$UNAME_RELEASE
++	;;
+     RISC*:Mach:*:*)
+-	echo mips-dec-mach_bsd4.3
+-	exit ;;
++	GUESS=mips-dec-mach_bsd4.3
++	;;
+     RISC*:ULTRIX:*:*)
+-	echo mips-dec-ultrix"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=mips-dec-ultrix$UNAME_RELEASE
++	;;
+     VAX*:ULTRIX*:*:*)
+-	echo vax-dec-ultrix"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=vax-dec-ultrix$UNAME_RELEASE
++	;;
+     2020:CLIX:*:* | 2430:CLIX:*:*)
+-	echo clipper-intergraph-clix"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=clipper-intergraph-clix$UNAME_RELEASE
++	;;
+     mips:*:*:UMIPS | mips:*:*:RISCos)
+-	eval "$set_cc_for_build"
++	set_cc_for_build
+ 	sed 's/^	//' << EOF > "$dummy.c"
+ #ifdef __cplusplus
+ #include <stdio.h>  /* for printf() prototype */
+@@ -508,78 +558,79 @@
+ 	  dummyarg=`echo "$UNAME_RELEASE" | sed -n 's/\([0-9]*\).*/\1/p'` &&
+ 	  SYSTEM_NAME=`"$dummy" "$dummyarg"` &&
+ 	    { echo "$SYSTEM_NAME"; exit; }
+-	echo mips-mips-riscos"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=mips-mips-riscos$UNAME_RELEASE
++	;;
+     Motorola:PowerMAX_OS:*:*)
+-	echo powerpc-motorola-powermax
+-	exit ;;
++	GUESS=powerpc-motorola-powermax
++	;;
+     Motorola:*:4.3:PL8-*)
+-	echo powerpc-harris-powermax
+-	exit ;;
++	GUESS=powerpc-harris-powermax
++	;;
+     Night_Hawk:*:*:PowerMAX_OS | Synergy:PowerMAX_OS:*:*)
+-	echo powerpc-harris-powermax
+-	exit ;;
++	GUESS=powerpc-harris-powermax
++	;;
+     Night_Hawk:Power_UNIX:*:*)
+-	echo powerpc-harris-powerunix
+-	exit ;;
++	GUESS=powerpc-harris-powerunix
++	;;
+     m88k:CX/UX:7*:*)
+-	echo m88k-harris-cxux7
+-	exit ;;
++	GUESS=m88k-harris-cxux7
++	;;
+     m88k:*:4*:R4*)
+-	echo m88k-motorola-sysv4
+-	exit ;;
++	GUESS=m88k-motorola-sysv4
++	;;
+     m88k:*:3*:R3*)
+-	echo m88k-motorola-sysv3
+-	exit ;;
++	GUESS=m88k-motorola-sysv3
++	;;
+     AViiON:dgux:*:*)
+ 	# DG/UX returns AViiON for all architectures
+ 	UNAME_PROCESSOR=`/usr/bin/uname -p`
+-	if [ "$UNAME_PROCESSOR" = mc88100 ] || [ "$UNAME_PROCESSOR" = mc88110 ]
++	if test "$UNAME_PROCESSOR" = mc88100 || test "$UNAME_PROCESSOR" = mc88110
+ 	then
+-	    if [ "$TARGET_BINARY_INTERFACE"x = m88kdguxelfx ] || \
+-	       [ "$TARGET_BINARY_INTERFACE"x = x ]
++	    if test "$TARGET_BINARY_INTERFACE"x = m88kdguxelfx || \
++	       test "$TARGET_BINARY_INTERFACE"x = x
+ 	    then
+-		echo m88k-dg-dgux"$UNAME_RELEASE"
++		GUESS=m88k-dg-dgux$UNAME_RELEASE
+ 	    else
+-		echo m88k-dg-dguxbcs"$UNAME_RELEASE"
++		GUESS=m88k-dg-dguxbcs$UNAME_RELEASE
+ 	    fi
+ 	else
+-	    echo i586-dg-dgux"$UNAME_RELEASE"
++	    GUESS=i586-dg-dgux$UNAME_RELEASE
+ 	fi
+-	exit ;;
++	;;
+     M88*:DolphinOS:*:*)	# DolphinOS (SVR3)
+-	echo m88k-dolphin-sysv3
+-	exit ;;
++	GUESS=m88k-dolphin-sysv3
++	;;
+     M88*:*:R3*:*)
+ 	# Delta 88k system running SVR3
+-	echo m88k-motorola-sysv3
+-	exit ;;
++	GUESS=m88k-motorola-sysv3
++	;;
+     XD88*:*:*:*) # Tektronix XD88 system running UTekV (SVR3)
+-	echo m88k-tektronix-sysv3
+-	exit ;;
++	GUESS=m88k-tektronix-sysv3
++	;;
+     Tek43[0-9][0-9]:UTek:*:*) # Tektronix 4300 system running UTek (BSD)
+-	echo m68k-tektronix-bsd
+-	exit ;;
++	GUESS=m68k-tektronix-bsd
++	;;
+     *:IRIX*:*:*)
+-	echo mips-sgi-irix"`echo "$UNAME_RELEASE"|sed -e 's/-/_/g'`"
+-	exit ;;
++	IRIX_REL=`echo "$UNAME_RELEASE" | sed -e 's/-/_/g'`
++	GUESS=mips-sgi-irix$IRIX_REL
++	;;
+     ????????:AIX?:[12].1:2)   # AIX 2.2.1 or AIX 2.1.1 is RT/PC AIX.
+-	echo romp-ibm-aix     # uname -m gives an 8 hex-code CPU id
+-	exit ;;               # Note that: echo "'`uname -s`'" gives 'AIX '
++	GUESS=romp-ibm-aix    # uname -m gives an 8 hex-code CPU id
++	;;                    # Note that: echo "'`uname -s`'" gives 'AIX '
+     i*86:AIX:*:*)
+-	echo i386-ibm-aix
+-	exit ;;
++	GUESS=i386-ibm-aix
++	;;
+     ia64:AIX:*:*)
+-	if [ -x /usr/bin/oslevel ] ; then
++	if test -x /usr/bin/oslevel ; then
+ 		IBM_REV=`/usr/bin/oslevel`
+ 	else
+-		IBM_REV="$UNAME_VERSION.$UNAME_RELEASE"
++		IBM_REV=$UNAME_VERSION.$UNAME_RELEASE
+ 	fi
+-	echo "$UNAME_MACHINE"-ibm-aix"$IBM_REV"
+-	exit ;;
++	GUESS=$UNAME_MACHINE-ibm-aix$IBM_REV
++	;;
+     *:AIX:2:3)
+ 	if grep bos325 /usr/include/stdio.h >/dev/null 2>&1; then
+-		eval "$set_cc_for_build"
++		set_cc_for_build
+ 		sed 's/^		//' << EOF > "$dummy.c"
+ 		#include <sys/systemcfg.h>
+ 
+@@ -593,16 +644,16 @@
+ EOF
+ 		if $CC_FOR_BUILD -o "$dummy" "$dummy.c" && SYSTEM_NAME=`"$dummy"`
+ 		then
+-			echo "$SYSTEM_NAME"
++			GUESS=$SYSTEM_NAME
+ 		else
+-			echo rs6000-ibm-aix3.2.5
++			GUESS=rs6000-ibm-aix3.2.5
+ 		fi
+ 	elif grep bos324 /usr/include/stdio.h >/dev/null 2>&1; then
+-		echo rs6000-ibm-aix3.2.4
++		GUESS=rs6000-ibm-aix3.2.4
+ 	else
+-		echo rs6000-ibm-aix3.2
++		GUESS=rs6000-ibm-aix3.2
+ 	fi
+-	exit ;;
++	;;
+     *:AIX:*:[4567])
+ 	IBM_CPU_ID=`/usr/sbin/lsdev -C -c processor -S available | sed 1q | awk '{ print $1 }'`
+ 	if /usr/sbin/lsattr -El "$IBM_CPU_ID" | grep ' POWER' >/dev/null 2>&1; then
+@@ -610,57 +661,57 @@
+ 	else
+ 		IBM_ARCH=powerpc
+ 	fi
+-	if [ -x /usr/bin/lslpp ] ; then
+-		IBM_REV=`/usr/bin/lslpp -Lqc bos.rte.libc |
++	if test -x /usr/bin/lslpp ; then
++		IBM_REV=`/usr/bin/lslpp -Lqc bos.rte.libc | \
+ 			   awk -F: '{ print $3 }' | sed s/[0-9]*$/0/`
+ 	else
+-		IBM_REV="$UNAME_VERSION.$UNAME_RELEASE"
++		IBM_REV=$UNAME_VERSION.$UNAME_RELEASE
+ 	fi
+-	echo "$IBM_ARCH"-ibm-aix"$IBM_REV"
+-	exit ;;
++	GUESS=$IBM_ARCH-ibm-aix$IBM_REV
++	;;
+     *:AIX:*:*)
+-	echo rs6000-ibm-aix
+-	exit ;;
++	GUESS=rs6000-ibm-aix
++	;;
+     ibmrt:4.4BSD:*|romp-ibm:4.4BSD:*)
+-	echo romp-ibm-bsd4.4
+-	exit ;;
++	GUESS=romp-ibm-bsd4.4
++	;;
+     ibmrt:*BSD:*|romp-ibm:BSD:*)            # covers RT/PC BSD and
+-	echo romp-ibm-bsd"$UNAME_RELEASE"   # 4.3 with uname added to
+-	exit ;;                             # report: romp-ibm BSD 4.3
++	GUESS=romp-ibm-bsd$UNAME_RELEASE    # 4.3 with uname added to
++	;;                                  # report: romp-ibm BSD 4.3
+     *:BOSX:*:*)
+-	echo rs6000-bull-bosx
+-	exit ;;
++	GUESS=rs6000-bull-bosx
++	;;
+     DPX/2?00:B.O.S.:*:*)
+-	echo m68k-bull-sysv3
+-	exit ;;
++	GUESS=m68k-bull-sysv3
++	;;
+     9000/[34]??:4.3bsd:1.*:*)
+-	echo m68k-hp-bsd
+-	exit ;;
++	GUESS=m68k-hp-bsd
++	;;
+     hp300:4.4BSD:*:* | 9000/[34]??:4.3bsd:2.*:*)
+-	echo m68k-hp-bsd4.4
+-	exit ;;
++	GUESS=m68k-hp-bsd4.4
++	;;
+     9000/[34678]??:HP-UX:*:*)
+-	HPUX_REV=`echo "$UNAME_RELEASE"|sed -e 's/[^.]*.[0B]*//'`
+-	case "$UNAME_MACHINE" in
++	HPUX_REV=`echo "$UNAME_RELEASE" | sed -e 's/[^.]*.[0B]*//'`
++	case $UNAME_MACHINE in
+ 	    9000/31?)            HP_ARCH=m68000 ;;
+ 	    9000/[34]??)         HP_ARCH=m68k ;;
+ 	    9000/[678][0-9][0-9])
+-		if [ -x /usr/bin/getconf ]; then
++		if test -x /usr/bin/getconf; then
+ 		    sc_cpu_version=`/usr/bin/getconf SC_CPU_VERSION 2>/dev/null`
+ 		    sc_kernel_bits=`/usr/bin/getconf SC_KERNEL_BITS 2>/dev/null`
+-		    case "$sc_cpu_version" in
++		    case $sc_cpu_version in
+ 		      523) HP_ARCH=hppa1.0 ;; # CPU_PA_RISC1_0
+ 		      528) HP_ARCH=hppa1.1 ;; # CPU_PA_RISC1_1
+ 		      532)                      # CPU_PA_RISC2_0
+-			case "$sc_kernel_bits" in
++			case $sc_kernel_bits in
+ 			  32) HP_ARCH=hppa2.0n ;;
+ 			  64) HP_ARCH=hppa2.0w ;;
+ 			  '') HP_ARCH=hppa2.0 ;;   # HP-UX 10.20
+ 			esac ;;
+ 		    esac
+ 		fi
+-		if [ "$HP_ARCH" = "" ]; then
+-		    eval "$set_cc_for_build"
++		if test "$HP_ARCH" = ""; then
++		    set_cc_for_build
+ 		    sed 's/^		//' << EOF > "$dummy.c"
+ 
+ 		#define _HPUX_SOURCE
+@@ -698,9 +749,9 @@
+ 		    test -z "$HP_ARCH" && HP_ARCH=hppa
+ 		fi ;;
+ 	esac
+-	if [ "$HP_ARCH" = hppa2.0w ]
++	if test "$HP_ARCH" = hppa2.0w
+ 	then
+-	    eval "$set_cc_for_build"
++	    set_cc_for_build
+ 
+ 	    # hppa2.0w-hp-hpux* has a 64-bit kernel and a compiler generating
+ 	    # 32-bit code.  hppa64-hp-hpux* has the same kernel and a compiler
+@@ -719,14 +770,14 @@
+ 		HP_ARCH=hppa64
+ 	    fi
+ 	fi
+-	echo "$HP_ARCH"-hp-hpux"$HPUX_REV"
+-	exit ;;
++	GUESS=$HP_ARCH-hp-hpux$HPUX_REV
++	;;
+     ia64:HP-UX:*:*)
+-	HPUX_REV=`echo "$UNAME_RELEASE"|sed -e 's/[^.]*.[0B]*//'`
+-	echo ia64-hp-hpux"$HPUX_REV"
+-	exit ;;
++	HPUX_REV=`echo "$UNAME_RELEASE" | sed -e 's/[^.]*.[0B]*//'`
++	GUESS=ia64-hp-hpux$HPUX_REV
++	;;
+     3050*:HI-UX:*:*)
+-	eval "$set_cc_for_build"
++	set_cc_for_build
+ 	sed 's/^	//' << EOF > "$dummy.c"
+ 	#include <unistd.h>
+ 	int
+@@ -754,36 +805,36 @@
+ EOF
+ 	$CC_FOR_BUILD -o "$dummy" "$dummy.c" && SYSTEM_NAME=`"$dummy"` &&
+ 		{ echo "$SYSTEM_NAME"; exit; }
+-	echo unknown-hitachi-hiuxwe2
+-	exit ;;
++	GUESS=unknown-hitachi-hiuxwe2
++	;;
+     9000/7??:4.3bsd:*:* | 9000/8?[79]:4.3bsd:*:*)
+-	echo hppa1.1-hp-bsd
+-	exit ;;
++	GUESS=hppa1.1-hp-bsd
++	;;
+     9000/8??:4.3bsd:*:*)
+-	echo hppa1.0-hp-bsd
+-	exit ;;
++	GUESS=hppa1.0-hp-bsd
++	;;
+     *9??*:MPE/iX:*:* | *3000*:MPE/iX:*:*)
+-	echo hppa1.0-hp-mpeix
+-	exit ;;
++	GUESS=hppa1.0-hp-mpeix
++	;;
+     hp7??:OSF1:*:* | hp8?[79]:OSF1:*:*)
+-	echo hppa1.1-hp-osf
+-	exit ;;
++	GUESS=hppa1.1-hp-osf
++	;;
+     hp8??:OSF1:*:*)
+-	echo hppa1.0-hp-osf
+-	exit ;;
++	GUESS=hppa1.0-hp-osf
++	;;
+     i*86:OSF1:*:*)
+-	if [ -x /usr/sbin/sysversion ] ; then
+-	    echo "$UNAME_MACHINE"-unknown-osf1mk
++	if test -x /usr/sbin/sysversion ; then
++	    GUESS=$UNAME_MACHINE-unknown-osf1mk
+ 	else
+-	    echo "$UNAME_MACHINE"-unknown-osf1
++	    GUESS=$UNAME_MACHINE-unknown-osf1
+ 	fi
+-	exit ;;
++	;;
+     parisc*:Lites*:*:*)
+-	echo hppa1.1-hp-lites
+-	exit ;;
++	GUESS=hppa1.1-hp-lites
++	;;
+     C1*:ConvexOS:*:* | convex:ConvexOS:C1*:*)
+-	echo c1-convex-bsd
+-	exit ;;
++	GUESS=c1-convex-bsd
++	;;
+     C2*:ConvexOS:*:* | convex:ConvexOS:C2*:*)
+ 	if getsysinfo -f scalar_acc
+ 	then echo c32-convex-bsd
+@@ -791,17 +842,18 @@
+ 	fi
+ 	exit ;;
+     C34*:ConvexOS:*:* | convex:ConvexOS:C34*:*)
+-	echo c34-convex-bsd
+-	exit ;;
++	GUESS=c34-convex-bsd
++	;;
+     C38*:ConvexOS:*:* | convex:ConvexOS:C38*:*)
+-	echo c38-convex-bsd
+-	exit ;;
++	GUESS=c38-convex-bsd
++	;;
+     C4*:ConvexOS:*:* | convex:ConvexOS:C4*:*)
+-	echo c4-convex-bsd
+-	exit ;;
++	GUESS=c4-convex-bsd
++	;;
+     CRAY*Y-MP:*:*:*)
+-	echo ymp-cray-unicos"$UNAME_RELEASE" | sed -e 's/\.[^.]*$/.X/'
+-	exit ;;
++	CRAY_REL=`echo "$UNAME_RELEASE" | sed -e 's/\.[^.]*$/.X/'`
++	GUESS=ymp-cray-unicos$CRAY_REL
++	;;
+     CRAY*[A-Z]90:*:*:*)
+ 	echo "$UNAME_MACHINE"-cray-unicos"$UNAME_RELEASE" \
+ 	| sed -e 's/CRAY.*\([A-Z]90\)/\1/' \
+@@ -809,103 +861,155 @@
+ 	      -e 's/\.[^.]*$/.X/'
+ 	exit ;;
+     CRAY*TS:*:*:*)
+-	echo t90-cray-unicos"$UNAME_RELEASE" | sed -e 's/\.[^.]*$/.X/'
+-	exit ;;
++	CRAY_REL=`echo "$UNAME_RELEASE" | sed -e 's/\.[^.]*$/.X/'`
++	GUESS=t90-cray-unicos$CRAY_REL
++	;;
+     CRAY*T3E:*:*:*)
+-	echo alphaev5-cray-unicosmk"$UNAME_RELEASE" | sed -e 's/\.[^.]*$/.X/'
+-	exit ;;
++	CRAY_REL=`echo "$UNAME_RELEASE" | sed -e 's/\.[^.]*$/.X/'`
++	GUESS=alphaev5-cray-unicosmk$CRAY_REL
++	;;
+     CRAY*SV1:*:*:*)
+-	echo sv1-cray-unicos"$UNAME_RELEASE" | sed -e 's/\.[^.]*$/.X/'
+-	exit ;;
++	CRAY_REL=`echo "$UNAME_RELEASE" | sed -e 's/\.[^.]*$/.X/'`
++	GUESS=sv1-cray-unicos$CRAY_REL
++	;;
+     *:UNICOS/mp:*:*)
+-	echo craynv-cray-unicosmp"$UNAME_RELEASE" | sed -e 's/\.[^.]*$/.X/'
+-	exit ;;
++	CRAY_REL=`echo "$UNAME_RELEASE" | sed -e 's/\.[^.]*$/.X/'`
++	GUESS=craynv-cray-unicosmp$CRAY_REL
++	;;
+     F30[01]:UNIX_System_V:*:* | F700:UNIX_System_V:*:*)
+ 	FUJITSU_PROC=`uname -m | tr ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz`
+ 	FUJITSU_SYS=`uname -p | tr ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz | sed -e 's/\///'`
+ 	FUJITSU_REL=`echo "$UNAME_RELEASE" | sed -e 's/ /_/'`
+-	echo "${FUJITSU_PROC}-fujitsu-${FUJITSU_SYS}${FUJITSU_REL}"
+-	exit ;;
++	GUESS=${FUJITSU_PROC}-fujitsu-${FUJITSU_SYS}${FUJITSU_REL}
++	;;
+     5000:UNIX_System_V:4.*:*)
+ 	FUJITSU_SYS=`uname -p | tr ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz | sed -e 's/\///'`
+ 	FUJITSU_REL=`echo "$UNAME_RELEASE" | tr ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz | sed -e 's/ /_/'`
+-	echo "sparc-fujitsu-${FUJITSU_SYS}${FUJITSU_REL}"
+-	exit ;;
++	GUESS=sparc-fujitsu-${FUJITSU_SYS}${FUJITSU_REL}
++	;;
+     i*86:BSD/386:*:* | i*86:BSD/OS:*:* | *:Ascend\ Embedded/OS:*:*)
+-	echo "$UNAME_MACHINE"-pc-bsdi"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=$UNAME_MACHINE-pc-bsdi$UNAME_RELEASE
++	;;
+     sparc*:BSD/OS:*:*)
+-	echo sparc-unknown-bsdi"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=sparc-unknown-bsdi$UNAME_RELEASE
++	;;
+     *:BSD/OS:*:*)
+-	echo "$UNAME_MACHINE"-unknown-bsdi"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=$UNAME_MACHINE-unknown-bsdi$UNAME_RELEASE
++	;;
++    arm:FreeBSD:*:*)
++	UNAME_PROCESSOR=`uname -p`
++	set_cc_for_build
++	if echo __ARM_PCS_VFP | $CC_FOR_BUILD -E - 2>/dev/null \
++	    | grep -q __ARM_PCS_VFP
++	then
++	    FREEBSD_REL=`echo "$UNAME_RELEASE" | sed -e 's/[-(].*//'`
++	    GUESS=$UNAME_PROCESSOR-unknown-freebsd$FREEBSD_REL-gnueabi
++	else
++	    FREEBSD_REL=`echo "$UNAME_RELEASE" | sed -e 's/[-(].*//'`
++	    GUESS=$UNAME_PROCESSOR-unknown-freebsd$FREEBSD_REL-gnueabihf
++	fi
++	;;
+     *:FreeBSD:*:*)
+-	UNAME_PROCESSOR=`/usr/bin/uname -p`
+-	case "$UNAME_PROCESSOR" in
++	UNAME_PROCESSOR=`uname -p`
++	case $UNAME_PROCESSOR in
+ 	    amd64)
+ 		UNAME_PROCESSOR=x86_64 ;;
+ 	    i386)
+ 		UNAME_PROCESSOR=i586 ;;
+ 	esac
+-	echo "$UNAME_PROCESSOR"-unknown-freebsd"`echo "$UNAME_RELEASE"|sed -e 's/[-(].*//'`"
+-	exit ;;
++	FREEBSD_REL=`echo "$UNAME_RELEASE" | sed -e 's/[-(].*//'`
++	GUESS=$UNAME_PROCESSOR-unknown-freebsd$FREEBSD_REL
++	;;
+     i*:CYGWIN*:*)
+-	echo "$UNAME_MACHINE"-pc-cygwin
+-	exit ;;
++	GUESS=$UNAME_MACHINE-pc-cygwin
++	;;
+     *:MINGW64*:*)
+-	echo "$UNAME_MACHINE"-pc-mingw64
+-	exit ;;
++	GUESS=$UNAME_MACHINE-pc-mingw64
++	;;
+     *:MINGW*:*)
+-	echo "$UNAME_MACHINE"-pc-mingw32
+-	exit ;;
++	GUESS=$UNAME_MACHINE-pc-mingw32
++	;;
+     *:MSYS*:*)
+-	echo "$UNAME_MACHINE"-pc-msys
+-	exit ;;
++	GUESS=$UNAME_MACHINE-pc-msys
++	;;
+     i*:PW*:*)
+-	echo "$UNAME_MACHINE"-pc-pw32
+-	exit ;;
++	GUESS=$UNAME_MACHINE-pc-pw32
++	;;
++    *:SerenityOS:*:*)
++        GUESS=$UNAME_MACHINE-pc-serenity
++        ;;
+     *:Interix*:*)
+-	case "$UNAME_MACHINE" in
++	case $UNAME_MACHINE in
+ 	    x86)
+-		echo i586-pc-interix"$UNAME_RELEASE"
+-		exit ;;
++		GUESS=i586-pc-interix$UNAME_RELEASE
++		;;
+ 	    authenticamd | genuineintel | EM64T)
+-		echo x86_64-unknown-interix"$UNAME_RELEASE"
+-		exit ;;
++		GUESS=x86_64-unknown-interix$UNAME_RELEASE
++		;;
+ 	    IA64)
+-		echo ia64-unknown-interix"$UNAME_RELEASE"
+-		exit ;;
++		GUESS=ia64-unknown-interix$UNAME_RELEASE
++		;;
+ 	esac ;;
+     i*:UWIN*:*)
+-	echo "$UNAME_MACHINE"-pc-uwin
+-	exit ;;
++	GUESS=$UNAME_MACHINE-pc-uwin
++	;;
+     amd64:CYGWIN*:*:* | x86_64:CYGWIN*:*:*)
+-	echo x86_64-unknown-cygwin
+-	exit ;;
++	GUESS=x86_64-pc-cygwin
++	;;
+     prep*:SunOS:5.*:*)
+-	echo powerpcle-unknown-solaris2"`echo "$UNAME_RELEASE"|sed -e 's/[^.]*//'`"
+-	exit ;;
++	SUN_REL=`echo "$UNAME_RELEASE" | sed -e 's/[^.]*//'`
++	GUESS=powerpcle-unknown-solaris2$SUN_REL
++	;;
+     *:GNU:*:*)
+ 	# the GNU system
+-	echo "`echo "$UNAME_MACHINE"|sed -e 's,[-/].*$,,'`-unknown-$LIBC`echo "$UNAME_RELEASE"|sed -e 's,/.*$,,'`"
+-	exit ;;
++	GNU_ARCH=`echo "$UNAME_MACHINE" | sed -e 's,[-/].*$,,'`
++	GNU_REL=`echo "$UNAME_RELEASE" | sed -e 's,/.*$,,'`
++	GUESS=$GNU_ARCH-unknown-$LIBC$GNU_REL
++	;;
+     *:GNU/*:*:*)
+ 	# other systems with GNU libc and userland
+-	echo "$UNAME_MACHINE-unknown-`echo "$UNAME_SYSTEM" | sed 's,^[^/]*/,,' | tr "[:upper:]" "[:lower:]"``echo "$UNAME_RELEASE"|sed -e 's/[-(].*//'`-$LIBC"
+-	exit ;;
+-    i*86:Minix:*:*)
+-	echo "$UNAME_MACHINE"-pc-minix
+-	exit ;;
++	GNU_SYS=`echo "$UNAME_SYSTEM" | sed 's,^[^/]*/,,' | tr "[:upper:]" "[:lower:]"`
++	GNU_REL=`echo "$UNAME_RELEASE" | sed -e 's/[-(].*//'`
++	GUESS=$UNAME_MACHINE-unknown-$GNU_SYS$GNU_REL-$LIBC
++	;;
++    x86_64:[Mm]anagarm:*:*|i?86:[Mm]anagarm:*:*)
++	GUESS="$UNAME_MACHINE-pc-managarm-mlibc"
++	;;
++    *:[Mm]anagarm:*:*)
++	GUESS="$UNAME_MACHINE-unknown-managarm-mlibc"
++	;;
++    *:Minix:*:*)
++	GUESS=$UNAME_MACHINE-unknown-minix
++	;;
+     aarch64:Linux:*:*)
+-	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+-	exit ;;
++	set_cc_for_build
++	CPU=$UNAME_MACHINE
++	LIBCABI=$LIBC
++	if test "$CC_FOR_BUILD" != no_compiler_found; then
++	    ABI=64
++	    sed 's/^	    //' << EOF > "$dummy.c"
++	    #ifdef __ARM_EABI__
++	    #ifdef __ARM_PCS_VFP
++	    ABI=eabihf
++	    #else
++	    ABI=eabi
++	    #endif
++	    #endif
++EOF
++	    cc_set_abi=`$CC_FOR_BUILD -E "$dummy.c" 2>/dev/null | grep '^ABI' | sed 's, ,,g'`
++	    eval "$cc_set_abi"
++	    case $ABI in
++		eabi | eabihf) CPU=armv8l; LIBCABI=$LIBC$ABI ;;
++	    esac
++	fi
++	GUESS=$CPU-unknown-linux-$LIBCABI
++	;;
+     aarch64_be:Linux:*:*)
+ 	UNAME_MACHINE=aarch64_be
+-	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+-	exit ;;
++	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
++	;;
+     alpha:Linux:*:*)
+-	case `sed -n '/^cpu model/s/^.*: \(.*\)/\1/p' < /proc/cpuinfo` in
++	case `sed -n '/^cpu model/s/^.*: \(.*\)/\1/p' /proc/cpuinfo 2>/dev/null` in
+ 	  EV5)   UNAME_MACHINE=alphaev5 ;;
+ 	  EV56)  UNAME_MACHINE=alphaev56 ;;
+ 	  PCA56) UNAME_MACHINE=alphapca56 ;;
+@@ -916,187 +1020,245 @@
+ 	esac
+ 	objdump --private-headers /bin/sh | grep -q ld.so.1
+ 	if test "$?" = 0 ; then LIBC=gnulibc1 ; fi
+-	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+-	exit ;;
+-    arc:Linux:*:* | arceb:Linux:*:*)
+-	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+-	exit ;;
++	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
++	;;
++    arc:Linux:*:* | arceb:Linux:*:* | arc32:Linux:*:* | arc64:Linux:*:*)
++	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
++	;;
+     arm*:Linux:*:*)
+-	eval "$set_cc_for_build"
++	set_cc_for_build
+ 	if echo __ARM_EABI__ | $CC_FOR_BUILD -E - 2>/dev/null \
+ 	    | grep -q __ARM_EABI__
+ 	then
+-	    echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
++	    GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
+ 	else
+ 	    if echo __ARM_PCS_VFP | $CC_FOR_BUILD -E - 2>/dev/null \
+ 		| grep -q __ARM_PCS_VFP
+ 	    then
+-		echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"eabi
++		GUESS=$UNAME_MACHINE-unknown-linux-${LIBC}eabi
+ 	    else
+-		echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"eabihf
++		GUESS=$UNAME_MACHINE-unknown-linux-${LIBC}eabihf
+ 	    fi
+ 	fi
+-	exit ;;
++	;;
+     avr32*:Linux:*:*)
+-	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+-	exit ;;
++	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
++	;;
+     cris:Linux:*:*)
+-	echo "$UNAME_MACHINE"-axis-linux-"$LIBC"
+-	exit ;;
++	GUESS=$UNAME_MACHINE-axis-linux-$LIBC
++	;;
+     crisv32:Linux:*:*)
+-	echo "$UNAME_MACHINE"-axis-linux-"$LIBC"
+-	exit ;;
++	GUESS=$UNAME_MACHINE-axis-linux-$LIBC
++	;;
+     e2k:Linux:*:*)
+-	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+-	exit ;;
++	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
++	;;
+     frv:Linux:*:*)
+-	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+-	exit ;;
++	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
++	;;
+     hexagon:Linux:*:*)
+-	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+-	exit ;;
++	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
++	;;
+     i*86:Linux:*:*)
+-	echo "$UNAME_MACHINE"-pc-linux-"$LIBC"
+-	exit ;;
++	GUESS=$UNAME_MACHINE-pc-linux-$LIBC
++	;;
+     ia64:Linux:*:*)
+-	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+-	exit ;;
++	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
++	;;
+     k1om:Linux:*:*)
+-	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+-	exit ;;
++	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
++	;;
++    kvx:Linux:*:*)
++	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
++	;;
++    kvx:cos:*:*)
++	GUESS=$UNAME_MACHINE-unknown-cos
++	;;
++    kvx:mbr:*:*)
++	GUESS=$UNAME_MACHINE-unknown-mbr
++	;;
++    loongarch32:Linux:*:* | loongarch64:Linux:*:*)
++	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
++	;;
+     m32r*:Linux:*:*)
+-	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+-	exit ;;
++	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
++	;;
+     m68*:Linux:*:*)
+-	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+-	exit ;;
++	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
++	;;
+     mips:Linux:*:* | mips64:Linux:*:*)
+-	eval "$set_cc_for_build"
++	set_cc_for_build
++	IS_GLIBC=0
++	test x"${LIBC}" = xgnu && IS_GLIBC=1
+ 	sed 's/^	//' << EOF > "$dummy.c"
+ 	#undef CPU
+-	#undef ${UNAME_MACHINE}
+-	#undef ${UNAME_MACHINE}el
++	#undef mips
++	#undef mipsel
++	#undef mips64
++	#undef mips64el
++	#if ${IS_GLIBC} && defined(_ABI64)
++	LIBCABI=gnuabi64
++	#else
++	#if ${IS_GLIBC} && defined(_ABIN32)
++	LIBCABI=gnuabin32
++	#else
++	LIBCABI=${LIBC}
++	#endif
++	#endif
++
++	#if ${IS_GLIBC} && defined(__mips64) && defined(__mips_isa_rev) && __mips_isa_rev>=6
++	CPU=mipsisa64r6
++	#else
++	#if ${IS_GLIBC} && !defined(__mips64) && defined(__mips_isa_rev) && __mips_isa_rev>=6
++	CPU=mipsisa32r6
++	#else
++	#if defined(__mips64)
++	CPU=mips64
++	#else
++	CPU=mips
++	#endif
++	#endif
++	#endif
++
+ 	#if defined(__MIPSEL__) || defined(__MIPSEL) || defined(_MIPSEL) || defined(MIPSEL)
+-	CPU=${UNAME_MACHINE}el
++	MIPS_ENDIAN=el
+ 	#else
+ 	#if defined(__MIPSEB__) || defined(__MIPSEB) || defined(_MIPSEB) || defined(MIPSEB)
+-	CPU=${UNAME_MACHINE}
++	MIPS_ENDIAN=
+ 	#else
+-	CPU=
++	MIPS_ENDIAN=
+ 	#endif
+ 	#endif
+ EOF
+-	eval "`$CC_FOR_BUILD -E "$dummy.c" 2>/dev/null | grep '^CPU'`"
+-	test "x$CPU" != x && { echo "$CPU-unknown-linux-$LIBC"; exit; }
++	cc_set_vars=`$CC_FOR_BUILD -E "$dummy.c" 2>/dev/null | grep '^CPU\|^MIPS_ENDIAN\|^LIBCABI'`
++	eval "$cc_set_vars"
++	test "x$CPU" != x && { echo "$CPU${MIPS_ENDIAN}-unknown-linux-$LIBCABI"; exit; }
+ 	;;
+     mips64el:Linux:*:*)
+-	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+-	exit ;;
++	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
++	;;
+     openrisc*:Linux:*:*)
+-	echo or1k-unknown-linux-"$LIBC"
+-	exit ;;
++	GUESS=or1k-unknown-linux-$LIBC
++	;;
+     or32:Linux:*:* | or1k*:Linux:*:*)
+-	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+-	exit ;;
++	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
++	;;
+     padre:Linux:*:*)
+-	echo sparc-unknown-linux-"$LIBC"
+-	exit ;;
++	GUESS=sparc-unknown-linux-$LIBC
++	;;
+     parisc64:Linux:*:* | hppa64:Linux:*:*)
+-	echo hppa64-unknown-linux-"$LIBC"
+-	exit ;;
++	GUESS=hppa64-unknown-linux-$LIBC
++	;;
+     parisc:Linux:*:* | hppa:Linux:*:*)
+ 	# Look for CPU level
+ 	case `grep '^cpu[^a-z]*:' /proc/cpuinfo 2>/dev/null | cut -d' ' -f2` in
+-	  PA7*) echo hppa1.1-unknown-linux-"$LIBC" ;;
+-	  PA8*) echo hppa2.0-unknown-linux-"$LIBC" ;;
+-	  *)    echo hppa-unknown-linux-"$LIBC" ;;
++	  PA7*) GUESS=hppa1.1-unknown-linux-$LIBC ;;
++	  PA8*) GUESS=hppa2.0-unknown-linux-$LIBC ;;
++	  *)    GUESS=hppa-unknown-linux-$LIBC ;;
+ 	esac
+-	exit ;;
++	;;
+     ppc64:Linux:*:*)
+-	echo powerpc64-unknown-linux-"$LIBC"
+-	exit ;;
++	GUESS=powerpc64-unknown-linux-$LIBC
++	;;
+     ppc:Linux:*:*)
+-	echo powerpc-unknown-linux-"$LIBC"
+-	exit ;;
++	GUESS=powerpc-unknown-linux-$LIBC
++	;;
+     ppc64le:Linux:*:*)
+-	echo powerpc64le-unknown-linux-"$LIBC"
+-	exit ;;
++	GUESS=powerpc64le-unknown-linux-$LIBC
++	;;
+     ppcle:Linux:*:*)
+-	echo powerpcle-unknown-linux-"$LIBC"
+-	exit ;;
+-    riscv32:Linux:*:* | riscv64:Linux:*:*)
+-	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+-	exit ;;
++	GUESS=powerpcle-unknown-linux-$LIBC
++	;;
++    riscv32:Linux:*:* | riscv32be:Linux:*:* | riscv64:Linux:*:* | riscv64be:Linux:*:*)
++	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
++	;;
+     s390:Linux:*:* | s390x:Linux:*:*)
+-	echo "$UNAME_MACHINE"-ibm-linux-"$LIBC"
+-	exit ;;
++	GUESS=$UNAME_MACHINE-ibm-linux-$LIBC
++	;;
+     sh64*:Linux:*:*)
+-	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+-	exit ;;
++	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
++	;;
+     sh*:Linux:*:*)
+-	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+-	exit ;;
++	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
++	;;
+     sparc:Linux:*:* | sparc64:Linux:*:*)
+-	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+-	exit ;;
++	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
++	;;
+     tile*:Linux:*:*)
+-	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+-	exit ;;
++	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
++	;;
+     vax:Linux:*:*)
+-	echo "$UNAME_MACHINE"-dec-linux-"$LIBC"
+-	exit ;;
++	GUESS=$UNAME_MACHINE-dec-linux-$LIBC
++	;;
+     x86_64:Linux:*:*)
+-	if objdump -f /bin/sh | grep -q elf32-x86-64; then
+-	    echo "$UNAME_MACHINE"-pc-linux-"$LIBC"x32
+-	else
+-	    echo "$UNAME_MACHINE"-pc-linux-"$LIBC"
++	set_cc_for_build
++	CPU=$UNAME_MACHINE
++	LIBCABI=$LIBC
++	if test "$CC_FOR_BUILD" != no_compiler_found; then
++	    ABI=64
++	    sed 's/^	    //' << EOF > "$dummy.c"
++	    #ifdef __i386__
++	    ABI=x86
++	    #else
++	    #ifdef __ILP32__
++	    ABI=x32
++	    #endif
++	    #endif
++EOF
++	    cc_set_abi=`$CC_FOR_BUILD -E "$dummy.c" 2>/dev/null | grep '^ABI' | sed 's, ,,g'`
++	    eval "$cc_set_abi"
++	    case $ABI in
++		x86) CPU=i686 ;;
++		x32) LIBCABI=${LIBC}x32 ;;
++	    esac
+ 	fi
+-	exit ;;
++	GUESS=$CPU-pc-linux-$LIBCABI
++	;;
+     xtensa*:Linux:*:*)
+-	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+-	exit ;;
++	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
++	;;
+     i*86:DYNIX/ptx:4*:*)
+ 	# ptx 4.0 does uname -s correctly, with DYNIX/ptx in there.
+ 	# earlier versions are messed up and put the nodename in both
+ 	# sysname and nodename.
+-	echo i386-sequent-sysv4
+-	exit ;;
++	GUESS=i386-sequent-sysv4
++	;;
+     i*86:UNIX_SV:4.2MP:2.*)
+ 	# Unixware is an offshoot of SVR4, but it has its own version
+ 	# number series starting with 2...
+ 	# I am not positive that other SVR4 systems won't match this,
+ 	# I just have to hope.  -- rms.
+ 	# Use sysv4.2uw... so that sysv4* matches it.
+-	echo "$UNAME_MACHINE"-pc-sysv4.2uw"$UNAME_VERSION"
+-	exit ;;
++	GUESS=$UNAME_MACHINE-pc-sysv4.2uw$UNAME_VERSION
++	;;
+     i*86:OS/2:*:*)
+-	# If we were able to find `uname', then EMX Unix compatibility
++	# If we were able to find 'uname', then EMX Unix compatibility
+ 	# is probably installed.
+-	echo "$UNAME_MACHINE"-pc-os2-emx
+-	exit ;;
++	GUESS=$UNAME_MACHINE-pc-os2-emx
++	;;
+     i*86:XTS-300:*:STOP)
+-	echo "$UNAME_MACHINE"-unknown-stop
+-	exit ;;
++	GUESS=$UNAME_MACHINE-unknown-stop
++	;;
+     i*86:atheos:*:*)
+-	echo "$UNAME_MACHINE"-unknown-atheos
+-	exit ;;
++	GUESS=$UNAME_MACHINE-unknown-atheos
++	;;
+     i*86:syllable:*:*)
+-	echo "$UNAME_MACHINE"-pc-syllable
+-	exit ;;
++	GUESS=$UNAME_MACHINE-pc-syllable
++	;;
+     i*86:LynxOS:2.*:* | i*86:LynxOS:3.[01]*:* | i*86:LynxOS:4.[02]*:*)
+-	echo i386-unknown-lynxos"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=i386-unknown-lynxos$UNAME_RELEASE
++	;;
+     i*86:*DOS:*:*)
+-	echo "$UNAME_MACHINE"-pc-msdosdjgpp
+-	exit ;;
++	GUESS=$UNAME_MACHINE-pc-msdosdjgpp
++	;;
+     i*86:*:4.*:*)
+ 	UNAME_REL=`echo "$UNAME_RELEASE" | sed 's/\/MP$//'`
+ 	if grep Novell /usr/include/link.h >/dev/null 2>/dev/null; then
+-		echo "$UNAME_MACHINE"-univel-sysv"$UNAME_REL"
++		GUESS=$UNAME_MACHINE-univel-sysv$UNAME_REL
+ 	else
+-		echo "$UNAME_MACHINE"-pc-sysv"$UNAME_REL"
++		GUESS=$UNAME_MACHINE-pc-sysv$UNAME_REL
+ 	fi
+-	exit ;;
++	;;
+     i*86:*:5:[678]*)
+ 	# UnixWare 7.x, OpenUNIX and OpenServer 6.
+ 	case `/bin/uname -X | grep "^Machine"` in
+@@ -1104,12 +1266,12 @@
+ 	    *Pentium)	     UNAME_MACHINE=i586 ;;
+ 	    *Pent*|*Celeron) UNAME_MACHINE=i686 ;;
+ 	esac
+-	echo "$UNAME_MACHINE-unknown-sysv${UNAME_RELEASE}${UNAME_SYSTEM}{$UNAME_VERSION}"
+-	exit ;;
++	GUESS=$UNAME_MACHINE-unknown-sysv${UNAME_RELEASE}${UNAME_SYSTEM}${UNAME_VERSION}
++	;;
+     i*86:*:3.2:*)
+ 	if test -f /usr/options/cb.name; then
+ 		UNAME_REL=`sed -n 's/.*Version //p' </usr/options/cb.name`
+-		echo "$UNAME_MACHINE"-pc-isc"$UNAME_REL"
++		GUESS=$UNAME_MACHINE-pc-isc$UNAME_REL
+ 	elif /bin/uname -X 2>/dev/null >/dev/null ; then
+ 		UNAME_REL=`(/bin/uname -X|grep Release|sed -e 's/.*= //')`
+ 		(/bin/uname -X|grep i80486 >/dev/null) && UNAME_MACHINE=i486
+@@ -1119,11 +1281,11 @@
+ 			&& UNAME_MACHINE=i686
+ 		(/bin/uname -X|grep '^Machine.*Pentium Pro' >/dev/null) \
+ 			&& UNAME_MACHINE=i686
+-		echo "$UNAME_MACHINE"-pc-sco"$UNAME_REL"
++		GUESS=$UNAME_MACHINE-pc-sco$UNAME_REL
+ 	else
+-		echo "$UNAME_MACHINE"-pc-sysv32
++		GUESS=$UNAME_MACHINE-pc-sysv32
+ 	fi
+-	exit ;;
++	;;
+     pc:*:*:*)
+ 	# Left here for compatibility:
+ 	# uname -m prints for DJGPP always 'pc', but it prints nothing about
+@@ -1131,31 +1293,31 @@
+ 	# Note: whatever this is, it MUST be the same as what config.sub
+ 	# prints for the "djgpp" host, or else GDB configure will decide that
+ 	# this is a cross-build.
+-	echo i586-pc-msdosdjgpp
+-	exit ;;
++	GUESS=i586-pc-msdosdjgpp
++	;;
+     Intel:Mach:3*:*)
+-	echo i386-pc-mach3
+-	exit ;;
++	GUESS=i386-pc-mach3
++	;;
+     paragon:*:*:*)
+-	echo i860-intel-osf1
+-	exit ;;
++	GUESS=i860-intel-osf1
++	;;
+     i860:*:4.*:*) # i860-SVR4
+ 	if grep Stardent /usr/include/sys/uadmin.h >/dev/null 2>&1 ; then
+-	  echo i860-stardent-sysv"$UNAME_RELEASE" # Stardent Vistra i860-SVR4
++	  GUESS=i860-stardent-sysv$UNAME_RELEASE    # Stardent Vistra i860-SVR4
+ 	else # Add other i860-SVR4 vendors below as they are discovered.
+-	  echo i860-unknown-sysv"$UNAME_RELEASE"  # Unknown i860-SVR4
++	  GUESS=i860-unknown-sysv$UNAME_RELEASE     # Unknown i860-SVR4
+ 	fi
+-	exit ;;
++	;;
+     mini*:CTIX:SYS*5:*)
+ 	# "miniframe"
+-	echo m68010-convergent-sysv
+-	exit ;;
++	GUESS=m68010-convergent-sysv
++	;;
+     mc68k:UNIX:SYSTEM5:3.51m)
+-	echo m68k-convergent-sysv
+-	exit ;;
++	GUESS=m68k-convergent-sysv
++	;;
+     M680?0:D-NIX:5.3:*)
+-	echo m68k-diab-dnix
+-	exit ;;
++	GUESS=m68k-diab-dnix
++	;;
+     M68*:*:R3V[5678]*:*)
+ 	test -r /sysV68 && { echo 'm68k-motorola-sysv'; exit; } ;;
+     3[345]??:*:4.0:3.0 | 3[34]??A:*:4.0:3.0 | 3[34]??,*:*:4.0:3.0 | 3[34]??/*:*:4.0:3.0 | 4400:*:4.0:3.0 | 4850:*:4.0:3.0 | SKA40:*:4.0:3.0 | SDS2:*:4.0:3.0 | SHG2:*:4.0:3.0 | S7501*:*:4.0:3.0)
+@@ -1180,249 +1342,410 @@
+ 	/bin/uname -p 2>/dev/null | /bin/grep pteron >/dev/null \
+ 	    && { echo i586-ncr-sysv4.3"$OS_REL"; exit; } ;;
+     m68*:LynxOS:2.*:* | m68*:LynxOS:3.0*:*)
+-	echo m68k-unknown-lynxos"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=m68k-unknown-lynxos$UNAME_RELEASE
++	;;
+     mc68030:UNIX_System_V:4.*:*)
+-	echo m68k-atari-sysv4
+-	exit ;;
++	GUESS=m68k-atari-sysv4
++	;;
+     TSUNAMI:LynxOS:2.*:*)
+-	echo sparc-unknown-lynxos"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=sparc-unknown-lynxos$UNAME_RELEASE
++	;;
+     rs6000:LynxOS:2.*:*)
+-	echo rs6000-unknown-lynxos"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=rs6000-unknown-lynxos$UNAME_RELEASE
++	;;
+     PowerPC:LynxOS:2.*:* | PowerPC:LynxOS:3.[01]*:* | PowerPC:LynxOS:4.[02]*:*)
+-	echo powerpc-unknown-lynxos"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=powerpc-unknown-lynxos$UNAME_RELEASE
++	;;
+     SM[BE]S:UNIX_SV:*:*)
+-	echo mips-dde-sysv"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=mips-dde-sysv$UNAME_RELEASE
++	;;
+     RM*:ReliantUNIX-*:*:*)
+-	echo mips-sni-sysv4
+-	exit ;;
++	GUESS=mips-sni-sysv4
++	;;
+     RM*:SINIX-*:*:*)
+-	echo mips-sni-sysv4
+-	exit ;;
++	GUESS=mips-sni-sysv4
++	;;
+     *:SINIX-*:*:*)
+ 	if uname -p 2>/dev/null >/dev/null ; then
+ 		UNAME_MACHINE=`(uname -p) 2>/dev/null`
+-		echo "$UNAME_MACHINE"-sni-sysv4
++		GUESS=$UNAME_MACHINE-sni-sysv4
+ 	else
+-		echo ns32k-sni-sysv
++		GUESS=ns32k-sni-sysv
+ 	fi
+-	exit ;;
+-    PENTIUM:*:4.0*:*)	# Unisys `ClearPath HMP IX 4000' SVR4/MP effort
++	;;
++    PENTIUM:*:4.0*:*)	# Unisys 'ClearPath HMP IX 4000' SVR4/MP effort
+ 			# says <Richard.M.Bartel@ccMail.Census.GOV>
+-	echo i586-unisys-sysv4
+-	exit ;;
++	GUESS=i586-unisys-sysv4
++	;;
+     *:UNIX_System_V:4*:FTX*)
+ 	# From Gerald Hewes <hewes@openmarket.com>.
+ 	# How about differentiating between stratus architectures? -djm
+-	echo hppa1.1-stratus-sysv4
+-	exit ;;
++	GUESS=hppa1.1-stratus-sysv4
++	;;
+     *:*:*:FTX*)
+ 	# From seanf@swdc.stratus.com.
+-	echo i860-stratus-sysv4
+-	exit ;;
++	GUESS=i860-stratus-sysv4
++	;;
+     i*86:VOS:*:*)
+ 	# From Paul.Green@stratus.com.
+-	echo "$UNAME_MACHINE"-stratus-vos
+-	exit ;;
++	GUESS=$UNAME_MACHINE-stratus-vos
++	;;
+     *:VOS:*:*)
+ 	# From Paul.Green@stratus.com.
+-	echo hppa1.1-stratus-vos
+-	exit ;;
++	GUESS=hppa1.1-stratus-vos
++	;;
+     mc68*:A/UX:*:*)
+-	echo m68k-apple-aux"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=m68k-apple-aux$UNAME_RELEASE
++	;;
+     news*:NEWS-OS:6*:*)
+-	echo mips-sony-newsos6
+-	exit ;;
++	GUESS=mips-sony-newsos6
++	;;
+     R[34]000:*System_V*:*:* | R4000:UNIX_SYSV:*:* | R*000:UNIX_SV:*:*)
+-	if [ -d /usr/nec ]; then
+-		echo mips-nec-sysv"$UNAME_RELEASE"
++	if test -d /usr/nec; then
++		GUESS=mips-nec-sysv$UNAME_RELEASE
+ 	else
+-		echo mips-unknown-sysv"$UNAME_RELEASE"
++		GUESS=mips-unknown-sysv$UNAME_RELEASE
+ 	fi
+-	exit ;;
++	;;
+     BeBox:BeOS:*:*)	# BeOS running on hardware made by Be, PPC only.
+-	echo powerpc-be-beos
+-	exit ;;
++	GUESS=powerpc-be-beos
++	;;
+     BeMac:BeOS:*:*)	# BeOS running on Mac or Mac clone, PPC only.
+-	echo powerpc-apple-beos
+-	exit ;;
++	GUESS=powerpc-apple-beos
++	;;
+     BePC:BeOS:*:*)	# BeOS running on Intel PC compatible.
+-	echo i586-pc-beos
+-	exit ;;
++	GUESS=i586-pc-beos
++	;;
+     BePC:Haiku:*:*)	# Haiku running on Intel PC compatible.
+-	echo i586-pc-haiku
+-	exit ;;
+-    x86_64:Haiku:*:*)
+-	echo x86_64-unknown-haiku
+-	exit ;;
++	GUESS=i586-pc-haiku
++	;;
++    ppc:Haiku:*:*)	# Haiku running on Apple PowerPC
++	GUESS=powerpc-apple-haiku
++	;;
++    *:Haiku:*:*)	# Haiku modern gcc (not bound by BeOS compat)
++	GUESS=$UNAME_MACHINE-unknown-haiku
++	;;
+     SX-4:SUPER-UX:*:*)
+-	echo sx4-nec-superux"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=sx4-nec-superux$UNAME_RELEASE
++	;;
+     SX-5:SUPER-UX:*:*)
+-	echo sx5-nec-superux"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=sx5-nec-superux$UNAME_RELEASE
++	;;
+     SX-6:SUPER-UX:*:*)
+-	echo sx6-nec-superux"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=sx6-nec-superux$UNAME_RELEASE
++	;;
+     SX-7:SUPER-UX:*:*)
+-	echo sx7-nec-superux"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=sx7-nec-superux$UNAME_RELEASE
++	;;
+     SX-8:SUPER-UX:*:*)
+-	echo sx8-nec-superux"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=sx8-nec-superux$UNAME_RELEASE
++	;;
+     SX-8R:SUPER-UX:*:*)
+-	echo sx8r-nec-superux"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=sx8r-nec-superux$UNAME_RELEASE
++	;;
+     SX-ACE:SUPER-UX:*:*)
+-	echo sxace-nec-superux"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=sxace-nec-superux$UNAME_RELEASE
++	;;
+     Power*:Rhapsody:*:*)
+-	echo powerpc-apple-rhapsody"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=powerpc-apple-rhapsody$UNAME_RELEASE
++	;;
+     *:Rhapsody:*:*)
+-	echo "$UNAME_MACHINE"-apple-rhapsody"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=$UNAME_MACHINE-apple-rhapsody$UNAME_RELEASE
++	;;
++    arm64:Darwin:*:*)
++	GUESS=aarch64-apple-darwin$UNAME_RELEASE
++	;;
+     *:Darwin:*:*)
+-	UNAME_PROCESSOR=`uname -p` || UNAME_PROCESSOR=unknown
+-	eval "$set_cc_for_build"
+-	if test "$UNAME_PROCESSOR" = unknown ; then
+-	    UNAME_PROCESSOR=powerpc
+-	fi
+-	if test "`echo "$UNAME_RELEASE" | sed -e 's/\..*//'`" -le 10 ; then
+-	    if [ "$CC_FOR_BUILD" != no_compiler_found ]; then
+-		if (echo '#ifdef __LP64__'; echo IS_64BIT_ARCH; echo '#endif') | \
+-		       (CCOPTS="" $CC_FOR_BUILD -E - 2>/dev/null) | \
+-		       grep IS_64BIT_ARCH >/dev/null
+-		then
+-		    case $UNAME_PROCESSOR in
+-			i386) UNAME_PROCESSOR=x86_64 ;;
+-			powerpc) UNAME_PROCESSOR=powerpc64 ;;
+-		    esac
+-		fi
+-		# On 10.4-10.6 one might compile for PowerPC via gcc -arch ppc
+-		if (echo '#ifdef __POWERPC__'; echo IS_PPC; echo '#endif') | \
+-		       (CCOPTS="" $CC_FOR_BUILD -E - 2>/dev/null) | \
+-		       grep IS_PPC >/dev/null
+-		then
+-		    UNAME_PROCESSOR=powerpc
+-		fi
++	UNAME_PROCESSOR=`uname -p`
++	case $UNAME_PROCESSOR in
++	    unknown) UNAME_PROCESSOR=powerpc ;;
++	esac
++	if command -v xcode-select > /dev/null 2> /dev/null && \
++		! xcode-select --print-path > /dev/null 2> /dev/null ; then
++	    # Avoid executing cc if there is no toolchain installed as
++	    # cc will be a stub that puts up a graphical alert
++	    # prompting the user to install developer tools.
++	    CC_FOR_BUILD=no_compiler_found
++	else
++	    set_cc_for_build
++	fi
++	if test "$CC_FOR_BUILD" != no_compiler_found; then
++	    if (echo '#ifdef __LP64__'; echo IS_64BIT_ARCH; echo '#endif') | \
++		   (CCOPTS="" $CC_FOR_BUILD -E - 2>/dev/null) | \
++		   grep IS_64BIT_ARCH >/dev/null
++	    then
++		case $UNAME_PROCESSOR in
++		    i386) UNAME_PROCESSOR=x86_64 ;;
++		    powerpc) UNAME_PROCESSOR=powerpc64 ;;
++		esac
++	    fi
++	    # On 10.4-10.6 one might compile for PowerPC via gcc -arch ppc
++	    if (echo '#ifdef __POWERPC__'; echo IS_PPC; echo '#endif') | \
++		   (CCOPTS="" $CC_FOR_BUILD -E - 2>/dev/null) | \
++		   grep IS_PPC >/dev/null
++	    then
++		UNAME_PROCESSOR=powerpc
+ 	    fi
+ 	elif test "$UNAME_PROCESSOR" = i386 ; then
+-	    # Avoid executing cc on OS X 10.9, as it ships with a stub
+-	    # that puts up a graphical alert prompting to install
+-	    # developer tools.  Any system running Mac OS X 10.7 or
+-	    # later (Darwin 11 and later) is required to have a 64-bit
+-	    # processor. This is not true of the ARM version of Darwin
+-	    # that Apple uses in portable devices.
+-	    UNAME_PROCESSOR=x86_64
++	    # uname -m returns i386 or x86_64
++	    UNAME_PROCESSOR=$UNAME_MACHINE
+ 	fi
+-	echo "$UNAME_PROCESSOR"-apple-darwin"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=$UNAME_PROCESSOR-apple-darwin$UNAME_RELEASE
++	;;
+     *:procnto*:*:* | *:QNX:[0123456789]*:*)
+ 	UNAME_PROCESSOR=`uname -p`
+ 	if test "$UNAME_PROCESSOR" = x86; then
+ 		UNAME_PROCESSOR=i386
+ 		UNAME_MACHINE=pc
+ 	fi
+-	echo "$UNAME_PROCESSOR"-"$UNAME_MACHINE"-nto-qnx"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=$UNAME_PROCESSOR-$UNAME_MACHINE-nto-qnx$UNAME_RELEASE
++	;;
+     *:QNX:*:4*)
+-	echo i386-pc-qnx
+-	exit ;;
++	GUESS=i386-pc-qnx
++	;;
+     NEO-*:NONSTOP_KERNEL:*:*)
+-	echo neo-tandem-nsk"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=neo-tandem-nsk$UNAME_RELEASE
++	;;
+     NSE-*:NONSTOP_KERNEL:*:*)
+-	echo nse-tandem-nsk"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=nse-tandem-nsk$UNAME_RELEASE
++	;;
+     NSR-*:NONSTOP_KERNEL:*:*)
+-	echo nsr-tandem-nsk"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=nsr-tandem-nsk$UNAME_RELEASE
++	;;
+     NSV-*:NONSTOP_KERNEL:*:*)
+-	echo nsv-tandem-nsk"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=nsv-tandem-nsk$UNAME_RELEASE
++	;;
+     NSX-*:NONSTOP_KERNEL:*:*)
+-	echo nsx-tandem-nsk"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=nsx-tandem-nsk$UNAME_RELEASE
++	;;
+     *:NonStop-UX:*:*)
+-	echo mips-compaq-nonstopux
+-	exit ;;
++	GUESS=mips-compaq-nonstopux
++	;;
+     BS2000:POSIX*:*:*)
+-	echo bs2000-siemens-sysv
+-	exit ;;
++	GUESS=bs2000-siemens-sysv
++	;;
+     DS/*:UNIX_System_V:*:*)
+-	echo "$UNAME_MACHINE"-"$UNAME_SYSTEM"-"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=$UNAME_MACHINE-$UNAME_SYSTEM-$UNAME_RELEASE
++	;;
+     *:Plan9:*:*)
+ 	# "uname -m" is not consistent, so use $cputype instead. 386
+ 	# is converted to i386 for consistency with other x86
+ 	# operating systems.
+-	if test "$cputype" = 386; then
++	if test "${cputype-}" = 386; then
+ 	    UNAME_MACHINE=i386
+-	else
+-	    UNAME_MACHINE="$cputype"
++	elif test "x${cputype-}" != x; then
++	    UNAME_MACHINE=$cputype
+ 	fi
+-	echo "$UNAME_MACHINE"-unknown-plan9
+-	exit ;;
++	GUESS=$UNAME_MACHINE-unknown-plan9
++	;;
+     *:TOPS-10:*:*)
+-	echo pdp10-unknown-tops10
+-	exit ;;
++	GUESS=pdp10-unknown-tops10
++	;;
+     *:TENEX:*:*)
+-	echo pdp10-unknown-tenex
+-	exit ;;
++	GUESS=pdp10-unknown-tenex
++	;;
+     KS10:TOPS-20:*:* | KL10:TOPS-20:*:* | TYPE4:TOPS-20:*:*)
+-	echo pdp10-dec-tops20
+-	exit ;;
++	GUESS=pdp10-dec-tops20
++	;;
+     XKL-1:TOPS-20:*:* | TYPE5:TOPS-20:*:*)
+-	echo pdp10-xkl-tops20
+-	exit ;;
++	GUESS=pdp10-xkl-tops20
++	;;
+     *:TOPS-20:*:*)
+-	echo pdp10-unknown-tops20
+-	exit ;;
++	GUESS=pdp10-unknown-tops20
++	;;
+     *:ITS:*:*)
+-	echo pdp10-unknown-its
+-	exit ;;
++	GUESS=pdp10-unknown-its
++	;;
+     SEI:*:*:SEIUX)
+-	echo mips-sei-seiux"$UNAME_RELEASE"
+-	exit ;;
++	GUESS=mips-sei-seiux$UNAME_RELEASE
++	;;
+     *:DragonFly:*:*)
+-	echo "$UNAME_MACHINE"-unknown-dragonfly"`echo "$UNAME_RELEASE"|sed -e 's/[-(].*//'`"
+-	exit ;;
++	DRAGONFLY_REL=`echo "$UNAME_RELEASE" | sed -e 's/[-(].*//'`
++	GUESS=$UNAME_MACHINE-unknown-dragonfly$DRAGONFLY_REL
++	;;
+     *:*VMS:*:*)
+ 	UNAME_MACHINE=`(uname -p) 2>/dev/null`
+-	case "$UNAME_MACHINE" in
+-	    A*) echo alpha-dec-vms ; exit ;;
+-	    I*) echo ia64-dec-vms ; exit ;;
+-	    V*) echo vax-dec-vms ; exit ;;
++	case $UNAME_MACHINE in
++	    A*) GUESS=alpha-dec-vms ;;
++	    I*) GUESS=ia64-dec-vms ;;
++	    V*) GUESS=vax-dec-vms ;;
+ 	esac ;;
+     *:XENIX:*:SysV)
+-	echo i386-pc-xenix
+-	exit ;;
++	GUESS=i386-pc-xenix
++	;;
+     i*86:skyos:*:*)
+-	echo "$UNAME_MACHINE"-pc-skyos"`echo "$UNAME_RELEASE" | sed -e 's/ .*$//'`"
+-	exit ;;
++	SKYOS_REL=`echo "$UNAME_RELEASE" | sed -e 's/ .*$//'`
++	GUESS=$UNAME_MACHINE-pc-skyos$SKYOS_REL
++	;;
+     i*86:rdos:*:*)
+-	echo "$UNAME_MACHINE"-pc-rdos
+-	exit ;;
+-    i*86:AROS:*:*)
+-	echo "$UNAME_MACHINE"-pc-aros
+-	exit ;;
++	GUESS=$UNAME_MACHINE-pc-rdos
++	;;
++    i*86:Fiwix:*:*)
++	GUESS=$UNAME_MACHINE-pc-fiwix
++	;;
++    *:AROS:*:*)
++	GUESS=$UNAME_MACHINE-unknown-aros
++	;;
+     x86_64:VMkernel:*:*)
+-	echo "$UNAME_MACHINE"-unknown-esx
+-	exit ;;
++	GUESS=$UNAME_MACHINE-unknown-esx
++	;;
+     amd64:Isilon\ OneFS:*:*)
+-	echo x86_64-unknown-onefs
+-	exit ;;
++	GUESS=x86_64-unknown-onefs
++	;;
++    *:Unleashed:*:*)
++	GUESS=$UNAME_MACHINE-unknown-unleashed$UNAME_RELEASE
++	;;
++    *:Ironclad:*:*)
++	GUESS=$UNAME_MACHINE-unknown-ironclad
++	;;
+ esac
+ 
++# Do we have a guess based on uname results?
++if test "x$GUESS" != x; then
++    echo "$GUESS"
++    exit
++fi
++
++# No uname command or uname output not recognized.
++set_cc_for_build
++cat > "$dummy.c" <<EOF
++#ifdef _SEQUENT_
++#include <sys/types.h>
++#include <sys/utsname.h>
++#endif
++#if defined(ultrix) || defined(_ultrix) || defined(__ultrix) || defined(__ultrix__)
++#if defined (vax) || defined (__vax) || defined (__vax__) || defined(mips) || defined(__mips) || defined(__mips__) || defined(MIPS) || defined(__MIPS__)
++#include <signal.h>
++#if defined(_SIZE_T_) || defined(SIGLOST)
++#include <sys/utsname.h>
++#endif
++#endif
++#endif
++main ()
++{
++#if defined (sony)
++#if defined (MIPSEB)
++  /* BFD wants "bsd" instead of "newsos".  Perhaps BFD should be changed,
++     I don't know....  */
++  printf ("mips-sony-bsd\n"); exit (0);
++#else
++#include <sys/param.h>
++  printf ("m68k-sony-newsos%s\n",
++#ifdef NEWSOS4
++  "4"
++#else
++  ""
++#endif
++  ); exit (0);
++#endif
++#endif
++
++#if defined (NeXT)
++#if !defined (__ARCHITECTURE__)
++#define __ARCHITECTURE__ "m68k"
++#endif
++  int version;
++  version=`(hostinfo | sed -n 's/.*NeXT Mach \([0-9]*\).*/\1/p') 2>/dev/null`;
++  if (version < 4)
++    printf ("%s-next-nextstep%d\n", __ARCHITECTURE__, version);
++  else
++    printf ("%s-next-openstep%d\n", __ARCHITECTURE__, version);
++  exit (0);
++#endif
++
++#if defined (MULTIMAX) || defined (n16)
++#if defined (UMAXV)
++  printf ("ns32k-encore-sysv\n"); exit (0);
++#else
++#if defined (CMU)
++  printf ("ns32k-encore-mach\n"); exit (0);
++#else
++  printf ("ns32k-encore-bsd\n"); exit (0);
++#endif
++#endif
++#endif
++
++#if defined (__386BSD__)
++  printf ("i386-pc-bsd\n"); exit (0);
++#endif
++
++#if defined (sequent)
++#if defined (i386)
++  printf ("i386-sequent-dynix\n"); exit (0);
++#endif
++#if defined (ns32000)
++  printf ("ns32k-sequent-dynix\n"); exit (0);
++#endif
++#endif
++
++#if defined (_SEQUENT_)
++  struct utsname un;
++
++  uname(&un);
++  if (strncmp(un.version, "V2", 2) == 0) {
++    printf ("i386-sequent-ptx2\n"); exit (0);
++  }
++  if (strncmp(un.version, "V1", 2) == 0) { /* XXX is V1 correct? */
++    printf ("i386-sequent-ptx1\n"); exit (0);
++  }
++  printf ("i386-sequent-ptx\n"); exit (0);
++#endif
++
++#if defined (vax)
++#if !defined (ultrix)
++#include <sys/param.h>
++#if defined (BSD)
++#if BSD == 43
++  printf ("vax-dec-bsd4.3\n"); exit (0);
++#else
++#if BSD == 199006
++  printf ("vax-dec-bsd4.3reno\n"); exit (0);
++#else
++  printf ("vax-dec-bsd\n"); exit (0);
++#endif
++#endif
++#else
++  printf ("vax-dec-bsd\n"); exit (0);
++#endif
++#else
++#if defined(_SIZE_T_) || defined(SIGLOST)
++  struct utsname un;
++  uname (&un);
++  printf ("vax-dec-ultrix%s\n", un.release); exit (0);
++#else
++  printf ("vax-dec-ultrix\n"); exit (0);
++#endif
++#endif
++#endif
++#if defined(ultrix) || defined(_ultrix) || defined(__ultrix) || defined(__ultrix__)
++#if defined(mips) || defined(__mips) || defined(__mips__) || defined(MIPS) || defined(__MIPS__)
++#if defined(_SIZE_T_) || defined(SIGLOST)
++  struct utsname *un;
++  uname (&un);
++  printf ("mips-dec-ultrix%s\n", un.release); exit (0);
++#else
++  printf ("mips-dec-ultrix\n"); exit (0);
++#endif
++#endif
++#endif
++
++#if defined (alliant) && defined (i860)
++  printf ("i860-alliant-bsd\n"); exit (0);
++#endif
++
++  exit (1);
++}
++EOF
++
++$CC_FOR_BUILD -o "$dummy" "$dummy.c" 2>/dev/null && SYSTEM_NAME=`"$dummy"` &&
++	{ echo "$SYSTEM_NAME"; exit; }
++
++# Apollos put the system type in the environment.
++test -d /usr/apollo && { echo "$ISP-apollo-$SYSTYPE"; exit; }
++
+ echo "$0: unable to guess system type" >&2
+ 
+-case "$UNAME_MACHINE:$UNAME_SYSTEM" in
++case $UNAME_MACHINE:$UNAME_SYSTEM in
+     mips:Linux | mips64:Linux)
+ 	# If we got here on MIPS GNU/Linux, output extra information.
+ 	cat >&2 <<EOF
+@@ -1439,9 +1762,17 @@
+ operating system you are using. If your script is old, overwrite *all*
+ copies of config.guess and config.sub with the latest versions from:
+ 
+-  https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess
++  https://git.savannah.gnu.org/cgit/config.git/plain/config.guess
+ and
+-  https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub
++  https://git.savannah.gnu.org/cgit/config.git/plain/config.sub
++EOF
++
++our_year=`echo $timestamp | sed 's,-.*,,'`
++thisyear=`date +%Y`
++# shellcheck disable=SC2003
++script_age=`expr "$thisyear" - "$our_year"`
++if test "$script_age" -lt 3 ; then
++   cat >&2 <<EOF
+ 
+ If $0 has already been updated, send the following data and any
+ information you think might be pertinent to config-patches@gnu.org to
+@@ -1469,11 +1800,12 @@
+ UNAME_SYSTEM  = "$UNAME_SYSTEM"
+ UNAME_VERSION = "$UNAME_VERSION"
+ EOF
++fi
+ 
+ exit 1
+ 
+ # Local variables:
+-# eval: (add-hook 'write-file-functions 'time-stamp)
++# eval: (add-hook 'before-save-hook 'time-stamp)
+ # time-stamp-start: "timestamp='"
+ # time-stamp-format: "%:y-%02m-%02d"
+ # time-stamp-end: "'"
+--- a/config/config.sub
++++ b/config/config.sub
+@@ -1,12 +1,14 @@
+ #! /bin/sh
+ # Configuration validation subroutine script.
+-#   Copyright 1992-2018 Free Software Foundation, Inc.
++#   Copyright 1992-2024 Free Software Foundation, Inc.
+ 
+-timestamp='2018-02-22'
++# shellcheck disable=SC2006,SC2268 # see below for rationale
++
++timestamp='2024-01-01'
+ 
+ # This file is free software; you can redistribute it and/or modify it
+ # under the terms of the GNU General Public License as published by
+-# the Free Software Foundation; either version 3 of the License, or
++# the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful, but
+@@ -33,7 +35,7 @@
+ # Otherwise, we print the canonical config type on stdout and succeed.
+ 
+ # You can get the latest version of this script from:
+-# https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub
++# https://git.savannah.gnu.org/cgit/config.git/plain/config.sub
+ 
+ # This file is supposed to be the same for all GNU packages
+ # and recognize all the CPU types, system types and aliases
+@@ -50,6 +52,13 @@
+ #	CPU_TYPE-MANUFACTURER-KERNEL-OPERATING_SYSTEM
+ # It is wrong to echo any other type of specification.
+ 
++# The "shellcheck disable" line above the timestamp inhibits complaints
++# about features and limitations of the classic Bourne shell that were
++# superseded or lifted in POSIX.  However, this script identifies a wide
++# variety of pre-POSIX systems that do not have POSIX shells at all, and
++# even some reasonably current systems (Solaris 10 as case-in-point) still
++# have a pre-POSIX /bin/sh.
++
+ me=`echo "$0" | sed -e 's,.*/,,'`
+ 
+ usage="\
+@@ -67,13 +76,13 @@
+ version="\
+ GNU config.sub ($timestamp)
+ 
+-Copyright 1992-2018 Free Software Foundation, Inc.
++Copyright 1992-2024 Free Software Foundation, Inc.
+ 
+ This is free software; see the source for copying conditions.  There is NO
+ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."
+ 
+ help="
+-Try \`$me --help' for more information."
++Try '$me --help' for more information."
+ 
+ # Parse command line
+ while test $# -gt 0 ; do
+@@ -89,7 +98,7 @@
+     - )	# Use stdin as input.
+        break ;;
+     -* )
+-       echo "$me: invalid option $1$help"
++       echo "$me: invalid option $1$help" >&2
+        exit 1 ;;
+ 
+     *local*)
+@@ -110,1223 +119,1167 @@
+     exit 1;;
+ esac
+ 
+-# Separate what the user gave into CPU-COMPANY and OS or KERNEL-OS (if any).
+-# Here we must recognize all the valid KERNEL-OS combinations.
+-maybe_os=`echo "$1" | sed 's/^\(.*\)-\([^-]*-[^-]*\)$/\2/'`
+-case $maybe_os in
+-  nto-qnx* | linux-gnu* | linux-android* | linux-dietlibc | linux-newlib* | \
+-  linux-musl* | linux-uclibc* | uclinux-uclibc* | uclinux-gnu* | kfreebsd*-gnu* | \
+-  knetbsd*-gnu* | netbsd*-gnu* | netbsd*-eabi* | \
+-  kopensolaris*-gnu* | cloudabi*-eabi* | \
+-  storm-chaos* | os2-emx* | rtmk-nova*)
+-    os=-$maybe_os
+-    basic_machine=`echo "$1" | sed 's/^\(.*\)-\([^-]*-[^-]*\)$/\1/'`
+-    ;;
+-  android-linux)
+-    os=-linux-android
+-    basic_machine=`echo "$1" | sed 's/^\(.*\)-\([^-]*-[^-]*\)$/\1/'`-unknown
+-    ;;
+-  *)
+-    basic_machine=`echo "$1" | sed 's/-[^-]*$//'`
+-    if [ "$basic_machine" != "$1" ]
+-    then os=`echo "$1" | sed 's/.*-/-/'`
+-    else os=; fi
+-    ;;
+-esac
+-
+-### Let's recognize common machines as not being operating systems so
+-### that things like config.sub decstation-3100 work.  We also
+-### recognize some manufacturers as not being operating systems, so we
+-### can provide default operating systems below.
+-case $os in
+-	-sun*os*)
+-		# Prevent following clause from handling this invalid input.
+-		;;
+-	-dec* | -mips* | -sequent* | -encore* | -pc532* | -sgi* | -sony* | \
+-	-att* | -7300* | -3300* | -delta* | -motorola* | -sun[234]* | \
+-	-unicom* | -ibm* | -next | -hp | -isi* | -apollo | -altos* | \
+-	-convergent* | -ncr* | -news | -32* | -3600* | -3100* | -hitachi* |\
+-	-c[123]* | -convex* | -sun | -crds | -omron* | -dg | -ultra | -tti* | \
+-	-harris | -dolphin | -highlevel | -gould | -cbm | -ns | -masscomp | \
+-	-apple | -axis | -knuth | -cray | -microblaze*)
+-		os=
+-		basic_machine=$1
+-		;;
+-	-bluegene*)
+-		os=-cnk
+-		;;
+-	-sim | -cisco | -oki | -wec | -winbond)
+-		os=
+-		basic_machine=$1
+-		;;
+-	-scout)
+-		;;
+-	-wrs)
+-		os=-vxworks
+-		basic_machine=$1
+-		;;
+-	-chorusos*)
+-		os=-chorusos
+-		basic_machine=$1
+-		;;
+-	-chorusrdb)
+-		os=-chorusrdb
+-		basic_machine=$1
+-		;;
+-	-hiux*)
+-		os=-hiuxwe2
+-		;;
+-	-sco6)
+-		os=-sco5v6
+-		basic_machine=`echo "$1" | sed -e 's/86-.*/86-pc/'`
+-		;;
+-	-sco5)
+-		os=-sco3.2v5
+-		basic_machine=`echo "$1" | sed -e 's/86-.*/86-pc/'`
+-		;;
+-	-sco4)
+-		os=-sco3.2v4
+-		basic_machine=`echo "$1" | sed -e 's/86-.*/86-pc/'`
+-		;;
+-	-sco3.2.[4-9]*)
+-		os=`echo $os | sed -e 's/sco3.2./sco3.2v/'`
+-		basic_machine=`echo "$1" | sed -e 's/86-.*/86-pc/'`
+-		;;
+-	-sco3.2v[4-9]*)
+-		# Don't forget version if it is 3.2v4 or newer.
+-		basic_machine=`echo "$1" | sed -e 's/86-.*/86-pc/'`
+-		;;
+-	-sco5v6*)
+-		# Don't forget version if it is 3.2v4 or newer.
+-		basic_machine=`echo "$1" | sed -e 's/86-.*/86-pc/'`
+-		;;
+-	-sco*)
+-		os=-sco3.2v2
+-		basic_machine=`echo "$1" | sed -e 's/86-.*/86-pc/'`
+-		;;
+-	-udk*)
+-		basic_machine=`echo "$1" | sed -e 's/86-.*/86-pc/'`
+-		;;
+-	-isc)
+-		os=-isc2.2
+-		basic_machine=`echo "$1" | sed -e 's/86-.*/86-pc/'`
+-		;;
+-	-clix*)
+-		basic_machine=clipper-intergraph
+-		;;
+-	-isc*)
+-		basic_machine=`echo "$1" | sed -e 's/86-.*/86-pc/'`
+-		;;
+-	-lynx*178)
+-		os=-lynxos178
+-		;;
+-	-lynx*5)
+-		os=-lynxos5
++# Split fields of configuration type
++# shellcheck disable=SC2162
++saved_IFS=$IFS
++IFS="-" read field1 field2 field3 field4 <<EOF
++$1
++EOF
++IFS=$saved_IFS
++
++# Separate into logical components for further validation
++case $1 in
++	*-*-*-*-*)
++		echo "Invalid configuration '$1': more than four components" >&2
++		exit 1
+ 		;;
+-	-lynx*)
+-		os=-lynxos
++	*-*-*-*)
++		basic_machine=$field1-$field2
++		basic_os=$field3-$field4
+ 		;;
+-	-ptx*)
+-		basic_machine=`echo "$1" | sed -e 's/86-.*/86-sequent/'`
++	*-*-*)
++		# Ambiguous whether COMPANY is present, or skipped and KERNEL-OS is two
++		# parts
++		maybe_os=$field2-$field3
++		case $maybe_os in
++			nto-qnx* | linux-* | uclinux-uclibc* \
++			| uclinux-gnu* | kfreebsd*-gnu* | knetbsd*-gnu* | netbsd*-gnu* \
++			| netbsd*-eabi* | kopensolaris*-gnu* | cloudabi*-eabi* \
++			| storm-chaos* | os2-emx* | rtmk-nova* | managarm-* \
++			| windows-* )
++				basic_machine=$field1
++				basic_os=$maybe_os
++				;;
++			android-linux)
++				basic_machine=$field1-unknown
++				basic_os=linux-android
++				;;
++			*)
++				basic_machine=$field1-$field2
++				basic_os=$field3
++				;;
++		esac
+ 		;;
+-	-psos*)
+-		os=-psos
++	*-*)
++		# A lone config we happen to match not fitting any pattern
++		case $field1-$field2 in
++			decstation-3100)
++				basic_machine=mips-dec
++				basic_os=
++				;;
++			*-*)
++				# Second component is usually, but not always the OS
++				case $field2 in
++					# Prevent following clause from handling this valid os
++					sun*os*)
++						basic_machine=$field1
++						basic_os=$field2
++						;;
++					zephyr*)
++						basic_machine=$field1-unknown
++						basic_os=$field2
++						;;
++					# Manufacturers
++					dec* | mips* | sequent* | encore* | pc533* | sgi* | sony* \
++					| att* | 7300* | 3300* | delta* | motorola* | sun[234]* \
++					| unicom* | ibm* | next | hp | isi* | apollo | altos* \
++					| convergent* | ncr* | news | 32* | 3600* | 3100* \
++					| hitachi* | c[123]* | convex* | sun | crds | omron* | dg \
++					| ultra | tti* | harris | dolphin | highlevel | gould \
++					| cbm | ns | masscomp | apple | axis | knuth | cray \
++					| microblaze* | sim | cisco \
++					| oki | wec | wrs | winbond)
++						basic_machine=$field1-$field2
++						basic_os=
++						;;
++					*)
++						basic_machine=$field1
++						basic_os=$field2
++						;;
++				esac
++			;;
++		esac
+ 		;;
+-	-mint | -mint[0-9]*)
+-		basic_machine=m68k-atari
+-		os=-mint
++	*)
++		# Convert single-component short-hands not valid as part of
++		# multi-component configurations.
++		case $field1 in
++			386bsd)
++				basic_machine=i386-pc
++				basic_os=bsd
++				;;
++			a29khif)
++				basic_machine=a29k-amd
++				basic_os=udi
++				;;
++			adobe68k)
++				basic_machine=m68010-adobe
++				basic_os=scout
++				;;
++			alliant)
++				basic_machine=fx80-alliant
++				basic_os=
++				;;
++			altos | altos3068)
++				basic_machine=m68k-altos
++				basic_os=
++				;;
++			am29k)
++				basic_machine=a29k-none
++				basic_os=bsd
++				;;
++			amdahl)
++				basic_machine=580-amdahl
++				basic_os=sysv
++				;;
++			amiga)
++				basic_machine=m68k-unknown
++				basic_os=
++				;;
++			amigaos | amigados)
++				basic_machine=m68k-unknown
++				basic_os=amigaos
++				;;
++			amigaunix | amix)
++				basic_machine=m68k-unknown
++				basic_os=sysv4
++				;;
++			apollo68)
++				basic_machine=m68k-apollo
++				basic_os=sysv
++				;;
++			apollo68bsd)
++				basic_machine=m68k-apollo
++				basic_os=bsd
++				;;
++			aros)
++				basic_machine=i386-pc
++				basic_os=aros
++				;;
++			aux)
++				basic_machine=m68k-apple
++				basic_os=aux
++				;;
++			balance)
++				basic_machine=ns32k-sequent
++				basic_os=dynix
++				;;
++			blackfin)
++				basic_machine=bfin-unknown
++				basic_os=linux
++				;;
++			cegcc)
++				basic_machine=arm-unknown
++				basic_os=cegcc
++				;;
++			convex-c1)
++				basic_machine=c1-convex
++				basic_os=bsd
++				;;
++			convex-c2)
++				basic_machine=c2-convex
++				basic_os=bsd
++				;;
++			convex-c32)
++				basic_machine=c32-convex
++				basic_os=bsd
++				;;
++			convex-c34)
++				basic_machine=c34-convex
++				basic_os=bsd
++				;;
++			convex-c38)
++				basic_machine=c38-convex
++				basic_os=bsd
++				;;
++			cray)
++				basic_machine=j90-cray
++				basic_os=unicos
++				;;
++			crds | unos)
++				basic_machine=m68k-crds
++				basic_os=
++				;;
++			da30)
++				basic_machine=m68k-da30
++				basic_os=
++				;;
++			decstation | pmax | pmin | dec3100 | decstatn)
++				basic_machine=mips-dec
++				basic_os=
++				;;
++			delta88)
++				basic_machine=m88k-motorola
++				basic_os=sysv3
++				;;
++			dicos)
++				basic_machine=i686-pc
++				basic_os=dicos
++				;;
++			djgpp)
++				basic_machine=i586-pc
++				basic_os=msdosdjgpp
++				;;
++			ebmon29k)
++				basic_machine=a29k-amd
++				basic_os=ebmon
++				;;
++			es1800 | OSE68k | ose68k | ose | OSE)
++				basic_machine=m68k-ericsson
++				basic_os=ose
++				;;
++			gmicro)
++				basic_machine=tron-gmicro
++				basic_os=sysv
++				;;
++			go32)
++				basic_machine=i386-pc
++				basic_os=go32
++				;;
++			h8300hms)
++				basic_machine=h8300-hitachi
++				basic_os=hms
++				;;
++			h8300xray)
++				basic_machine=h8300-hitachi
++				basic_os=xray
++				;;
++			h8500hms)
++				basic_machine=h8500-hitachi
++				basic_os=hms
++				;;
++			harris)
++				basic_machine=m88k-harris
++				basic_os=sysv3
++				;;
++			hp300 | hp300hpux)
++				basic_machine=m68k-hp
++				basic_os=hpux
++				;;
++			hp300bsd)
++				basic_machine=m68k-hp
++				basic_os=bsd
++				;;
++			hppaosf)
++				basic_machine=hppa1.1-hp
++				basic_os=osf
++				;;
++			hppro)
++				basic_machine=hppa1.1-hp
++				basic_os=proelf
++				;;
++			i386mach)
++				basic_machine=i386-mach
++				basic_os=mach
++				;;
++			isi68 | isi)
++				basic_machine=m68k-isi
++				basic_os=sysv
++				;;
++			m68knommu)
++				basic_machine=m68k-unknown
++				basic_os=linux
++				;;
++			magnum | m3230)
++				basic_machine=mips-mips
++				basic_os=sysv
++				;;
++			merlin)
++				basic_machine=ns32k-utek
++				basic_os=sysv
++				;;
++			mingw64)
++				basic_machine=x86_64-pc
++				basic_os=mingw64
++				;;
++			mingw32)
++				basic_machine=i686-pc
++				basic_os=mingw32
++				;;
++			mingw32ce)
++				basic_machine=arm-unknown
++				basic_os=mingw32ce
++				;;
++			monitor)
++				basic_machine=m68k-rom68k
++				basic_os=coff
++				;;
++			morphos)
++				basic_machine=powerpc-unknown
++				basic_os=morphos
++				;;
++			moxiebox)
++				basic_machine=moxie-unknown
++				basic_os=moxiebox
++				;;
++			msdos)
++				basic_machine=i386-pc
++				basic_os=msdos
++				;;
++			msys)
++				basic_machine=i686-pc
++				basic_os=msys
++				;;
++			mvs)
++				basic_machine=i370-ibm
++				basic_os=mvs
++				;;
++			nacl)
++				basic_machine=le32-unknown
++				basic_os=nacl
++				;;
++			ncr3000)
++				basic_machine=i486-ncr
++				basic_os=sysv4
++				;;
++			netbsd386)
++				basic_machine=i386-pc
++				basic_os=netbsd
++				;;
++			netwinder)
++				basic_machine=armv4l-rebel
++				basic_os=linux
++				;;
++			news | news700 | news800 | news900)
++				basic_machine=m68k-sony
++				basic_os=newsos
++				;;
++			news1000)
++				basic_machine=m68030-sony
++				basic_os=newsos
++				;;
++			necv70)
++				basic_machine=v70-nec
++				basic_os=sysv
++				;;
++			nh3000)
++				basic_machine=m68k-harris
++				basic_os=cxux
++				;;
++			nh[45]000)
++				basic_machine=m88k-harris
++				basic_os=cxux
++				;;
++			nindy960)
++				basic_machine=i960-intel
++				basic_os=nindy
++				;;
++			mon960)
++				basic_machine=i960-intel
++				basic_os=mon960
++				;;
++			nonstopux)
++				basic_machine=mips-compaq
++				basic_os=nonstopux
++				;;
++			os400)
++				basic_machine=powerpc-ibm
++				basic_os=os400
++				;;
++			OSE68000 | ose68000)
++				basic_machine=m68000-ericsson
++				basic_os=ose
++				;;
++			os68k)
++				basic_machine=m68k-none
++				basic_os=os68k
++				;;
++			paragon)
++				basic_machine=i860-intel
++				basic_os=osf
++				;;
++			parisc)
++				basic_machine=hppa-unknown
++				basic_os=linux
++				;;
++			psp)
++				basic_machine=mipsallegrexel-sony
++				basic_os=psp
++				;;
++			pw32)
++				basic_machine=i586-unknown
++				basic_os=pw32
++				;;
++			rdos | rdos64)
++				basic_machine=x86_64-pc
++				basic_os=rdos
++				;;
++			rdos32)
++				basic_machine=i386-pc
++				basic_os=rdos
++				;;
++			rom68k)
++				basic_machine=m68k-rom68k
++				basic_os=coff
++				;;
++			sa29200)
++				basic_machine=a29k-amd
++				basic_os=udi
++				;;
++			sei)
++				basic_machine=mips-sei
++				basic_os=seiux
++				;;
++			sequent)
++				basic_machine=i386-sequent
++				basic_os=
++				;;
++			sps7)
++				basic_machine=m68k-bull
++				basic_os=sysv2
++				;;
++			st2000)
++				basic_machine=m68k-tandem
++				basic_os=
++				;;
++			stratus)
++				basic_machine=i860-stratus
++				basic_os=sysv4
++				;;
++			sun2)
++				basic_machine=m68000-sun
++				basic_os=
++				;;
++			sun2os3)
++				basic_machine=m68000-sun
++				basic_os=sunos3
++				;;
++			sun2os4)
++				basic_machine=m68000-sun
++				basic_os=sunos4
++				;;
++			sun3)
++				basic_machine=m68k-sun
++				basic_os=
++				;;
++			sun3os3)
++				basic_machine=m68k-sun
++				basic_os=sunos3
++				;;
++			sun3os4)
++				basic_machine=m68k-sun
++				basic_os=sunos4
++				;;
++			sun4)
++				basic_machine=sparc-sun
++				basic_os=
++				;;
++			sun4os3)
++				basic_machine=sparc-sun
++				basic_os=sunos3
++				;;
++			sun4os4)
++				basic_machine=sparc-sun
++				basic_os=sunos4
++				;;
++			sun4sol2)
++				basic_machine=sparc-sun
++				basic_os=solaris2
++				;;
++			sun386 | sun386i | roadrunner)
++				basic_machine=i386-sun
++				basic_os=
++				;;
++			sv1)
++				basic_machine=sv1-cray
++				basic_os=unicos
++				;;
++			symmetry)
++				basic_machine=i386-sequent
++				basic_os=dynix
++				;;
++			t3e)
++				basic_machine=alphaev5-cray
++				basic_os=unicos
++				;;
++			t90)
++				basic_machine=t90-cray
++				basic_os=unicos
++				;;
++			toad1)
++				basic_machine=pdp10-xkl
++				basic_os=tops20
++				;;
++			tpf)
++				basic_machine=s390x-ibm
++				basic_os=tpf
++				;;
++			udi29k)
++				basic_machine=a29k-amd
++				basic_os=udi
++				;;
++			ultra3)
++				basic_machine=a29k-nyu
++				basic_os=sym1
++				;;
++			v810 | necv810)
++				basic_machine=v810-nec
++				basic_os=none
++				;;
++			vaxv)
++				basic_machine=vax-dec
++				basic_os=sysv
++				;;
++			vms)
++				basic_machine=vax-dec
++				basic_os=vms
++				;;
++			vsta)
++				basic_machine=i386-pc
++				basic_os=vsta
++				;;
++			vxworks960)
++				basic_machine=i960-wrs
++				basic_os=vxworks
++				;;
++			vxworks68)
++				basic_machine=m68k-wrs
++				basic_os=vxworks
++				;;
++			vxworks29k)
++				basic_machine=a29k-wrs
++				basic_os=vxworks
++				;;
++			xbox)
++				basic_machine=i686-pc
++				basic_os=mingw32
++				;;
++			ymp)
++				basic_machine=ymp-cray
++				basic_os=unicos
++				;;
++			*)
++				basic_machine=$1
++				basic_os=
++				;;
++		esac
+ 		;;
+ esac
+ 
+-# Decode aliases for certain CPU-COMPANY combinations.
++# Decode 1-component or ad-hoc basic machines
+ case $basic_machine in
+-	# Recognize the basic CPU types without company name.
+-	# Some are omitted here because they have special meanings below.
+-	1750a | 580 \
+-	| a29k \
+-	| aarch64 | aarch64_be \
+-	| alpha | alphaev[4-8] | alphaev56 | alphaev6[78] | alphapca5[67] \
+-	| alpha64 | alpha64ev[4-8] | alpha64ev56 | alpha64ev6[78] | alpha64pca5[67] \
+-	| am33_2.0 \
+-	| arc | arceb \
+-	| arm | arm[bl]e | arme[lb] | armv[2-8] | armv[3-8][lb] | armv7[arm] \
+-	| avr | avr32 \
+-	| ba \
+-	| be32 | be64 \
+-	| bfin \
+-	| c4x | c8051 | clipper \
+-	| d10v | d30v | dlx | dsp16xx \
+-	| e2k | epiphany \
+-	| fido | fr30 | frv | ft32 \
+-	| h8300 | h8500 | hppa | hppa1.[01] | hppa2.0 | hppa2.0[nw] | hppa64 \
+-	| hexagon \
+-	| i370 | i860 | i960 | ia16 | ia64 \
+-	| ip2k | iq2000 \
+-	| k1om \
+-	| le32 | le64 \
+-	| lm32 \
+-	| m32c | m32r | m32rle | m68000 | m68k | m88k \
+-	| maxq | mb | microblaze | microblazeel | mcore | mep | metag \
+-	| mips | mipsbe | mipseb | mipsel | mipsle \
+-	| mips16 \
+-	| mips64 | mips64el \
+-	| mips64octeon | mips64octeonel \
+-	| mips64orion | mips64orionel \
+-	| mips64r5900 | mips64r5900el \
+-	| mips64vr | mips64vrel \
+-	| mips64vr4100 | mips64vr4100el \
+-	| mips64vr4300 | mips64vr4300el \
+-	| mips64vr5000 | mips64vr5000el \
+-	| mips64vr5900 | mips64vr5900el \
+-	| mipsisa32 | mipsisa32el \
+-	| mipsisa32r2 | mipsisa32r2el \
+-	| mipsisa32r6 | mipsisa32r6el \
+-	| mipsisa64 | mipsisa64el \
+-	| mipsisa64r2 | mipsisa64r2el \
+-	| mipsisa64r6 | mipsisa64r6el \
+-	| mipsisa64sb1 | mipsisa64sb1el \
+-	| mipsisa64sr71k | mipsisa64sr71kel \
+-	| mipsr5900 | mipsr5900el \
+-	| mipstx39 | mipstx39el \
+-	| mn10200 | mn10300 \
+-	| moxie \
+-	| mt \
+-	| msp430 \
+-	| nds32 | nds32le | nds32be \
+-	| nios | nios2 | nios2eb | nios2el \
+-	| ns16k | ns32k \
+-	| open8 | or1k | or1knd | or32 \
+-	| pdp10 | pj | pjl \
+-	| powerpc | powerpc64 | powerpc64le | powerpcle \
+-	| pru \
+-	| pyramid \
+-	| riscv32 | riscv64 \
+-	| rl78 | rx \
+-	| score \
+-	| sh | sh[1234] | sh[24]a | sh[24]aeb | sh[23]e | sh[234]eb | sheb | shbe | shle | sh[1234]le | sh3ele \
+-	| sh64 | sh64le \
+-	| sparc | sparc64 | sparc64b | sparc64v | sparc86x | sparclet | sparclite \
+-	| sparcv8 | sparcv9 | sparcv9b | sparcv9v \
+-	| spu \
+-	| tahoe | tic4x | tic54x | tic55x | tic6x | tic80 | tron \
+-	| ubicom32 \
+-	| v850 | v850e | v850e1 | v850e2 | v850es | v850e2v3 \
+-	| visium \
+-	| wasm32 \
+-	| x86 | xc16x | xstormy16 | xtensa \
+-	| z8k | z80)
+-		basic_machine=$basic_machine-unknown
+-		;;
+-	c54x)
+-		basic_machine=tic54x-unknown
+-		;;
+-	c55x)
+-		basic_machine=tic55x-unknown
+-		;;
+-	c6x)
+-		basic_machine=tic6x-unknown
+-		;;
+-	leon|leon[3-9])
+-		basic_machine=sparc-$basic_machine
+-		;;
+-	m6811 | m68hc11 | m6812 | m68hc12 | m68hcs12x | nvptx | picochip)
+-		basic_machine=$basic_machine-unknown
+-		os=-none
++	# Here we handle the default manufacturer of certain CPU types.  It is in
++	# some cases the only manufacturer, in others, it is the most popular.
++	w89k)
++		cpu=hppa1.1
++		vendor=winbond
+ 		;;
+-	m88110 | m680[12346]0 | m683?2 | m68360 | m5200 | v70 | w65)
++	op50n)
++		cpu=hppa1.1
++		vendor=oki
+ 		;;
+-	ms1)
+-		basic_machine=mt-unknown
++	op60c)
++		cpu=hppa1.1
++		vendor=oki
+ 		;;
+-
+-	strongarm | thumb | xscale)
+-		basic_machine=arm-unknown
++	ibm*)
++		cpu=i370
++		vendor=ibm
+ 		;;
+-	xgate)
+-		basic_machine=$basic_machine-unknown
+-		os=-none
++	orion105)
++		cpu=clipper
++		vendor=highlevel
+ 		;;
+-	xscaleeb)
+-		basic_machine=armeb-unknown
++	mac | mpw | mac-mpw)
++		cpu=m68k
++		vendor=apple
+ 		;;
+-
+-	xscaleel)
+-		basic_machine=armel-unknown
++	pmac | pmac-mpw)
++		cpu=powerpc
++		vendor=apple
+ 		;;
+ 
+-	# We use `pc' rather than `unknown'
+-	# because (1) that's what they normally are, and
+-	# (2) the word "unknown" tends to confuse beginning users.
+-	i*86 | x86_64)
+-	  basic_machine=$basic_machine-pc
+-	  ;;
+-	# Object if more than one company name word.
+-	*-*-*)
+-		echo Invalid configuration \`"$1"\': machine \`"$basic_machine"\' not recognized 1>&2
+-		exit 1
+-		;;
+-	# Recognize the basic CPU types with company name.
+-	580-* \
+-	| a29k-* \
+-	| aarch64-* | aarch64_be-* \
+-	| alpha-* | alphaev[4-8]-* | alphaev56-* | alphaev6[78]-* \
+-	| alpha64-* | alpha64ev[4-8]-* | alpha64ev56-* | alpha64ev6[78]-* \
+-	| alphapca5[67]-* | alpha64pca5[67]-* | arc-* | arceb-* \
+-	| arm-*  | armbe-* | armle-* | armeb-* | armv*-* \
+-	| avr-* | avr32-* \
+-	| ba-* \
+-	| be32-* | be64-* \
+-	| bfin-* | bs2000-* \
+-	| c[123]* | c30-* | [cjt]90-* | c4x-* \
+-	| c8051-* | clipper-* | craynv-* | cydra-* \
+-	| d10v-* | d30v-* | dlx-* \
+-	| e2k-* | elxsi-* \
+-	| f30[01]-* | f700-* | fido-* | fr30-* | frv-* | fx80-* \
+-	| h8300-* | h8500-* \
+-	| hppa-* | hppa1.[01]-* | hppa2.0-* | hppa2.0[nw]-* | hppa64-* \
+-	| hexagon-* \
+-	| i*86-* | i860-* | i960-* | ia16-* | ia64-* \
+-	| ip2k-* | iq2000-* \
+-	| k1om-* \
+-	| le32-* | le64-* \
+-	| lm32-* \
+-	| m32c-* | m32r-* | m32rle-* \
+-	| m68000-* | m680[012346]0-* | m68360-* | m683?2-* | m68k-* \
+-	| m88110-* | m88k-* | maxq-* | mcore-* | metag-* \
+-	| microblaze-* | microblazeel-* \
+-	| mips-* | mipsbe-* | mipseb-* | mipsel-* | mipsle-* \
+-	| mips16-* \
+-	| mips64-* | mips64el-* \
+-	| mips64octeon-* | mips64octeonel-* \
+-	| mips64orion-* | mips64orionel-* \
+-	| mips64r5900-* | mips64r5900el-* \
+-	| mips64vr-* | mips64vrel-* \
+-	| mips64vr4100-* | mips64vr4100el-* \
+-	| mips64vr4300-* | mips64vr4300el-* \
+-	| mips64vr5000-* | mips64vr5000el-* \
+-	| mips64vr5900-* | mips64vr5900el-* \
+-	| mipsisa32-* | mipsisa32el-* \
+-	| mipsisa32r2-* | mipsisa32r2el-* \
+-	| mipsisa32r6-* | mipsisa32r6el-* \
+-	| mipsisa64-* | mipsisa64el-* \
+-	| mipsisa64r2-* | mipsisa64r2el-* \
+-	| mipsisa64r6-* | mipsisa64r6el-* \
+-	| mipsisa64sb1-* | mipsisa64sb1el-* \
+-	| mipsisa64sr71k-* | mipsisa64sr71kel-* \
+-	| mipsr5900-* | mipsr5900el-* \
+-	| mipstx39-* | mipstx39el-* \
+-	| mmix-* \
+-	| mt-* \
+-	| msp430-* \
+-	| nds32-* | nds32le-* | nds32be-* \
+-	| nios-* | nios2-* | nios2eb-* | nios2el-* \
+-	| none-* | np1-* | ns16k-* | ns32k-* \
+-	| open8-* \
+-	| or1k*-* \
+-	| orion-* \
+-	| pdp10-* | pdp11-* | pj-* | pjl-* | pn-* | power-* \
+-	| powerpc-* | powerpc64-* | powerpc64le-* | powerpcle-* \
+-	| pru-* \
+-	| pyramid-* \
+-	| riscv32-* | riscv64-* \
+-	| rl78-* | romp-* | rs6000-* | rx-* \
+-	| sh-* | sh[1234]-* | sh[24]a-* | sh[24]aeb-* | sh[23]e-* | sh[34]eb-* | sheb-* | shbe-* \
+-	| shle-* | sh[1234]le-* | sh3ele-* | sh64-* | sh64le-* \
+-	| sparc-* | sparc64-* | sparc64b-* | sparc64v-* | sparc86x-* | sparclet-* \
+-	| sparclite-* \
+-	| sparcv8-* | sparcv9-* | sparcv9b-* | sparcv9v-* | sv1-* | sx*-* \
+-	| tahoe-* \
+-	| tic30-* | tic4x-* | tic54x-* | tic55x-* | tic6x-* | tic80-* \
+-	| tile*-* \
+-	| tron-* \
+-	| ubicom32-* \
+-	| v850-* | v850e-* | v850e1-* | v850es-* | v850e2-* | v850e2v3-* \
+-	| vax-* \
+-	| visium-* \
+-	| wasm32-* \
+-	| we32k-* \
+-	| x86-* | x86_64-* | xc16x-* | xps100-* \
+-	| xstormy16-* | xtensa*-* \
+-	| ymp-* \
+-	| z8k-* | z80-*)
+-		;;
+-	# Recognize the basic CPU types without company name, with glob match.
+-	xtensa*)
+-		basic_machine=$basic_machine-unknown
+-		;;
+ 	# Recognize the various machine names and aliases which stand
+ 	# for a CPU type and a company and sometimes even an OS.
+-	386bsd)
+-		basic_machine=i386-pc
+-		os=-bsd
+-		;;
+ 	3b1 | 7300 | 7300-att | att-7300 | pc7300 | safari | unixpc)
+-		basic_machine=m68000-att
++		cpu=m68000
++		vendor=att
+ 		;;
+ 	3b*)
+-		basic_machine=we32k-att
+-		;;
+-	a29khif)
+-		basic_machine=a29k-amd
+-		os=-udi
+-		;;
+-	abacus)
+-		basic_machine=abacus-unknown
+-		;;
+-	adobe68k)
+-		basic_machine=m68010-adobe
+-		os=-scout
+-		;;
+-	alliant | fx80)
+-		basic_machine=fx80-alliant
+-		;;
+-	altos | altos3068)
+-		basic_machine=m68k-altos
+-		;;
+-	am29k)
+-		basic_machine=a29k-none
+-		os=-bsd
+-		;;
+-	amd64)
+-		basic_machine=x86_64-pc
+-		;;
+-	amd64-*)
+-		basic_machine=x86_64-`echo "$basic_machine" | sed 's/^[^-]*-//'`
+-		;;
+-	amdahl)
+-		basic_machine=580-amdahl
+-		os=-sysv
+-		;;
+-	amiga | amiga-*)
+-		basic_machine=m68k-unknown
+-		;;
+-	amigaos | amigados)
+-		basic_machine=m68k-unknown
+-		os=-amigaos
+-		;;
+-	amigaunix | amix)
+-		basic_machine=m68k-unknown
+-		os=-sysv4
+-		;;
+-	apollo68)
+-		basic_machine=m68k-apollo
+-		os=-sysv
+-		;;
+-	apollo68bsd)
+-		basic_machine=m68k-apollo
+-		os=-bsd
+-		;;
+-	aros)
+-		basic_machine=i386-pc
+-		os=-aros
+-		;;
+-	asmjs)
+-		basic_machine=asmjs-unknown
+-		;;
+-	aux)
+-		basic_machine=m68k-apple
+-		os=-aux
+-		;;
+-	balance)
+-		basic_machine=ns32k-sequent
+-		os=-dynix
+-		;;
+-	blackfin)
+-		basic_machine=bfin-unknown
+-		os=-linux
+-		;;
+-	blackfin-*)
+-		basic_machine=bfin-`echo "$basic_machine" | sed 's/^[^-]*-//'`
+-		os=-linux
++		cpu=we32k
++		vendor=att
+ 		;;
+ 	bluegene*)
+-		basic_machine=powerpc-ibm
+-		os=-cnk
+-		;;
+-	c54x-*)
+-		basic_machine=tic54x-`echo "$basic_machine" | sed 's/^[^-]*-//'`
+-		;;
+-	c55x-*)
+-		basic_machine=tic55x-`echo "$basic_machine" | sed 's/^[^-]*-//'`
+-		;;
+-	c6x-*)
+-		basic_machine=tic6x-`echo "$basic_machine" | sed 's/^[^-]*-//'`
+-		;;
+-	c90)
+-		basic_machine=c90-cray
+-		os=-unicos
+-		;;
+-	cegcc)
+-		basic_machine=arm-unknown
+-		os=-cegcc
+-		;;
+-	convex-c1)
+-		basic_machine=c1-convex
+-		os=-bsd
+-		;;
+-	convex-c2)
+-		basic_machine=c2-convex
+-		os=-bsd
+-		;;
+-	convex-c32)
+-		basic_machine=c32-convex
+-		os=-bsd
+-		;;
+-	convex-c34)
+-		basic_machine=c34-convex
+-		os=-bsd
+-		;;
+-	convex-c38)
+-		basic_machine=c38-convex
+-		os=-bsd
+-		;;
+-	cray | j90)
+-		basic_machine=j90-cray
+-		os=-unicos
+-		;;
+-	craynv)
+-		basic_machine=craynv-cray
+-		os=-unicosmp
+-		;;
+-	cr16 | cr16-*)
+-		basic_machine=cr16-unknown
+-		os=-elf
+-		;;
+-	crds | unos)
+-		basic_machine=m68k-crds
+-		;;
+-	crisv32 | crisv32-* | etraxfs*)
+-		basic_machine=crisv32-axis
+-		;;
+-	cris | cris-* | etrax*)
+-		basic_machine=cris-axis
+-		;;
+-	crx)
+-		basic_machine=crx-unknown
+-		os=-elf
+-		;;
+-	da30 | da30-*)
+-		basic_machine=m68k-da30
+-		;;
+-	decstation | decstation-3100 | pmax | pmax-* | pmin | dec3100 | decstatn)
+-		basic_machine=mips-dec
++		cpu=powerpc
++		vendor=ibm
++		basic_os=cnk
+ 		;;
+ 	decsystem10* | dec10*)
+-		basic_machine=pdp10-dec
+-		os=-tops10
++		cpu=pdp10
++		vendor=dec
++		basic_os=tops10
+ 		;;
+ 	decsystem20* | dec20*)
+-		basic_machine=pdp10-dec
+-		os=-tops20
++		cpu=pdp10
++		vendor=dec
++		basic_os=tops20
+ 		;;
+ 	delta | 3300 | motorola-3300 | motorola-delta \
+ 	      | 3300-motorola | delta-motorola)
+-		basic_machine=m68k-motorola
+-		;;
+-	delta88)
+-		basic_machine=m88k-motorola
+-		os=-sysv3
+-		;;
+-	dicos)
+-		basic_machine=i686-pc
+-		os=-dicos
+-		;;
+-	djgpp)
+-		basic_machine=i586-pc
+-		os=-msdosdjgpp
+-		;;
+-	dpx20 | dpx20-*)
+-		basic_machine=rs6000-bull
+-		os=-bosx
++		cpu=m68k
++		vendor=motorola
+ 		;;
+ 	dpx2*)
+-		basic_machine=m68k-bull
+-		os=-sysv3
+-		;;
+-	e500v[12])
+-		basic_machine=powerpc-unknown
+-		os=$os"spe"
+-		;;
+-	e500v[12]-*)
+-		basic_machine=powerpc-`echo "$basic_machine" | sed 's/^[^-]*-//'`
+-		os=$os"spe"
+-		;;
+-	ebmon29k)
+-		basic_machine=a29k-amd
+-		os=-ebmon
+-		;;
+-	elxsi)
+-		basic_machine=elxsi-elxsi
+-		os=-bsd
++		cpu=m68k
++		vendor=bull
++		basic_os=sysv3
+ 		;;
+ 	encore | umax | mmax)
+-		basic_machine=ns32k-encore
++		cpu=ns32k
++		vendor=encore
+ 		;;
+-	es1800 | OSE68k | ose68k | ose | OSE)
+-		basic_machine=m68k-ericsson
+-		os=-ose
++	elxsi)
++		cpu=elxsi
++		vendor=elxsi
++		basic_os=${basic_os:-bsd}
+ 		;;
+ 	fx2800)
+-		basic_machine=i860-alliant
++		cpu=i860
++		vendor=alliant
+ 		;;
+ 	genix)
+-		basic_machine=ns32k-ns
+-		;;
+-	gmicro)
+-		basic_machine=tron-gmicro
+-		os=-sysv
+-		;;
+-	go32)
+-		basic_machine=i386-pc
+-		os=-go32
++		cpu=ns32k
++		vendor=ns
+ 		;;
+ 	h3050r* | hiux*)
+-		basic_machine=hppa1.1-hitachi
+-		os=-hiuxwe2
+-		;;
+-	h8300hms)
+-		basic_machine=h8300-hitachi
+-		os=-hms
+-		;;
+-	h8300xray)
+-		basic_machine=h8300-hitachi
+-		os=-xray
+-		;;
+-	h8500hms)
+-		basic_machine=h8500-hitachi
+-		os=-hms
+-		;;
+-	harris)
+-		basic_machine=m88k-harris
+-		os=-sysv3
+-		;;
+-	hp300-*)
+-		basic_machine=m68k-hp
+-		;;
+-	hp300bsd)
+-		basic_machine=m68k-hp
+-		os=-bsd
+-		;;
+-	hp300hpux)
+-		basic_machine=m68k-hp
+-		os=-hpux
++		cpu=hppa1.1
++		vendor=hitachi
++		basic_os=hiuxwe2
+ 		;;
+ 	hp3k9[0-9][0-9] | hp9[0-9][0-9])
+-		basic_machine=hppa1.0-hp
++		cpu=hppa1.0
++		vendor=hp
+ 		;;
+ 	hp9k2[0-9][0-9] | hp9k31[0-9])
+-		basic_machine=m68000-hp
++		cpu=m68000
++		vendor=hp
+ 		;;
+ 	hp9k3[2-9][0-9])
+-		basic_machine=m68k-hp
++		cpu=m68k
++		vendor=hp
+ 		;;
+ 	hp9k6[0-9][0-9] | hp6[0-9][0-9])
+-		basic_machine=hppa1.0-hp
++		cpu=hppa1.0
++		vendor=hp
+ 		;;
+ 	hp9k7[0-79][0-9] | hp7[0-79][0-9])
+-		basic_machine=hppa1.1-hp
++		cpu=hppa1.1
++		vendor=hp
+ 		;;
+ 	hp9k78[0-9] | hp78[0-9])
+ 		# FIXME: really hppa2.0-hp
+-		basic_machine=hppa1.1-hp
++		cpu=hppa1.1
++		vendor=hp
+ 		;;
+ 	hp9k8[67]1 | hp8[67]1 | hp9k80[24] | hp80[24] | hp9k8[78]9 | hp8[78]9 | hp9k893 | hp893)
+ 		# FIXME: really hppa2.0-hp
+-		basic_machine=hppa1.1-hp
++		cpu=hppa1.1
++		vendor=hp
+ 		;;
+ 	hp9k8[0-9][13679] | hp8[0-9][13679])
+-		basic_machine=hppa1.1-hp
++		cpu=hppa1.1
++		vendor=hp
+ 		;;
+ 	hp9k8[0-9][0-9] | hp8[0-9][0-9])
+-		basic_machine=hppa1.0-hp
+-		;;
+-	hppaosf)
+-		basic_machine=hppa1.1-hp
+-		os=-osf
+-		;;
+-	hppro)
+-		basic_machine=hppa1.1-hp
+-		os=-proelf
+-		;;
+-	i370-ibm* | ibm*)
+-		basic_machine=i370-ibm
++		cpu=hppa1.0
++		vendor=hp
+ 		;;
+ 	i*86v32)
+-		basic_machine=`echo "$1" | sed -e 's/86.*/86-pc/'`
+-		os=-sysv32
++		cpu=`echo "$1" | sed -e 's/86.*/86/'`
++		vendor=pc
++		basic_os=sysv32
+ 		;;
+ 	i*86v4*)
+-		basic_machine=`echo "$1" | sed -e 's/86.*/86-pc/'`
+-		os=-sysv4
++		cpu=`echo "$1" | sed -e 's/86.*/86/'`
++		vendor=pc
++		basic_os=sysv4
+ 		;;
+ 	i*86v)
+-		basic_machine=`echo "$1" | sed -e 's/86.*/86-pc/'`
+-		os=-sysv
++		cpu=`echo "$1" | sed -e 's/86.*/86/'`
++		vendor=pc
++		basic_os=sysv
+ 		;;
+ 	i*86sol2)
+-		basic_machine=`echo "$1" | sed -e 's/86.*/86-pc/'`
+-		os=-solaris2
+-		;;
+-	i386mach)
+-		basic_machine=i386-mach
+-		os=-mach
+-		;;
+-	vsta)
+-		basic_machine=i386-unknown
+-		os=-vsta
++		cpu=`echo "$1" | sed -e 's/86.*/86/'`
++		vendor=pc
++		basic_os=solaris2
++		;;
++	j90 | j90-cray)
++		cpu=j90
++		vendor=cray
++		basic_os=${basic_os:-unicos}
+ 		;;
+ 	iris | iris4d)
+-		basic_machine=mips-sgi
+-		case $os in
+-		    -irix*)
++		cpu=mips
++		vendor=sgi
++		case $basic_os in
++		    irix*)
+ 			;;
+ 		    *)
+-			os=-irix4
++			basic_os=irix4
+ 			;;
+ 		esac
+ 		;;
+-	isi68 | isi)
+-		basic_machine=m68k-isi
+-		os=-sysv
+-		;;
+-	leon-*|leon[3-9]-*)
+-		basic_machine=sparc-`echo "$basic_machine" | sed 's/-.*//'`
+-		;;
+-	m68knommu)
+-		basic_machine=m68k-unknown
+-		os=-linux
+-		;;
+-	m68knommu-*)
+-		basic_machine=m68k-`echo "$basic_machine" | sed 's/^[^-]*-//'`
+-		os=-linux
+-		;;
+-	magnum | m3230)
+-		basic_machine=mips-mips
+-		os=-sysv
+-		;;
+-	merlin)
+-		basic_machine=ns32k-utek
+-		os=-sysv
+-		;;
+-	microblaze*)
+-		basic_machine=microblaze-xilinx
+-		;;
+-	mingw64)
+-		basic_machine=x86_64-pc
+-		os=-mingw64
+-		;;
+-	mingw32)
+-		basic_machine=i686-pc
+-		os=-mingw32
+-		;;
+-	mingw32ce)
+-		basic_machine=arm-unknown
+-		os=-mingw32ce
+-		;;
+ 	miniframe)
+-		basic_machine=m68000-convergent
++		cpu=m68000
++		vendor=convergent
+ 		;;
+-	*mint | -mint[0-9]* | *MiNT | *MiNT[0-9]*)
+-		basic_machine=m68k-atari
+-		os=-mint
+-		;;
+-	mips3*-*)
+-		basic_machine=`echo "$basic_machine" | sed -e 's/mips3/mips64/'`
+-		;;
+-	mips3*)
+-		basic_machine=`echo "$basic_machine" | sed -e 's/mips3/mips64/'`-unknown
+-		;;
+-	monitor)
+-		basic_machine=m68k-rom68k
+-		os=-coff
+-		;;
+-	morphos)
+-		basic_machine=powerpc-unknown
+-		os=-morphos
+-		;;
+-	moxiebox)
+-		basic_machine=moxie-unknown
+-		os=-moxiebox
+-		;;
+-	msdos)
+-		basic_machine=i386-pc
+-		os=-msdos
+-		;;
+-	ms1-*)
+-		basic_machine=`echo "$basic_machine" | sed -e 's/ms1-/mt-/'`
+-		;;
+-	msys)
+-		basic_machine=i686-pc
+-		os=-msys
+-		;;
+-	mvs)
+-		basic_machine=i370-ibm
+-		os=-mvs
+-		;;
+-	nacl)
+-		basic_machine=le32-unknown
+-		os=-nacl
+-		;;
+-	ncr3000)
+-		basic_machine=i486-ncr
+-		os=-sysv4
+-		;;
+-	netbsd386)
+-		basic_machine=i386-unknown
+-		os=-netbsd
+-		;;
+-	netwinder)
+-		basic_machine=armv4l-rebel
+-		os=-linux
+-		;;
+-	news | news700 | news800 | news900)
+-		basic_machine=m68k-sony
+-		os=-newsos
+-		;;
+-	news1000)
+-		basic_machine=m68030-sony
+-		os=-newsos
++	*mint | mint[0-9]* | *MiNT | *MiNT[0-9]*)
++		cpu=m68k
++		vendor=atari
++		basic_os=mint
+ 		;;
+ 	news-3600 | risc-news)
+-		basic_machine=mips-sony
+-		os=-newsos
+-		;;
+-	necv70)
+-		basic_machine=v70-nec
+-		os=-sysv
++		cpu=mips
++		vendor=sony
++		basic_os=newsos
+ 		;;
+ 	next | m*-next)
+-		basic_machine=m68k-next
+-		case $os in
+-		    -nextstep* )
++		cpu=m68k
++		vendor=next
++		case $basic_os in
++		    openstep*)
++		        ;;
++		    nextstep*)
+ 			;;
+-		    -ns2*)
+-		      os=-nextstep2
++		    ns2*)
++		      basic_os=nextstep2
+ 			;;
+ 		    *)
+-		      os=-nextstep3
++		      basic_os=nextstep3
+ 			;;
+ 		esac
+ 		;;
+-	nh3000)
+-		basic_machine=m68k-harris
+-		os=-cxux
+-		;;
+-	nh[45]000)
+-		basic_machine=m88k-harris
+-		os=-cxux
+-		;;
+-	nindy960)
+-		basic_machine=i960-intel
+-		os=-nindy
+-		;;
+-	mon960)
+-		basic_machine=i960-intel
+-		os=-mon960
+-		;;
+-	nonstopux)
+-		basic_machine=mips-compaq
+-		os=-nonstopux
+-		;;
+ 	np1)
+-		basic_machine=np1-gould
+-		;;
+-	neo-tandem)
+-		basic_machine=neo-tandem
+-		;;
+-	nse-tandem)
+-		basic_machine=nse-tandem
+-		;;
+-	nsr-tandem)
+-		basic_machine=nsr-tandem
+-		;;
+-	nsv-tandem)
+-		basic_machine=nsv-tandem
+-		;;
+-	nsx-tandem)
+-		basic_machine=nsx-tandem
++		cpu=np1
++		vendor=gould
+ 		;;
+ 	op50n-* | op60c-*)
+-		basic_machine=hppa1.1-oki
+-		os=-proelf
+-		;;
+-	openrisc | openrisc-*)
+-		basic_machine=or32-unknown
+-		;;
+-	os400)
+-		basic_machine=powerpc-ibm
+-		os=-os400
+-		;;
+-	OSE68000 | ose68000)
+-		basic_machine=m68000-ericsson
+-		os=-ose
+-		;;
+-	os68k)
+-		basic_machine=m68k-none
+-		os=-os68k
++		cpu=hppa1.1
++		vendor=oki
++		basic_os=proelf
+ 		;;
+ 	pa-hitachi)
+-		basic_machine=hppa1.1-hitachi
+-		os=-hiuxwe2
+-		;;
+-	paragon)
+-		basic_machine=i860-intel
+-		os=-osf
+-		;;
+-	parisc)
+-		basic_machine=hppa-unknown
+-		os=-linux
+-		;;
+-	parisc-*)
+-		basic_machine=hppa-`echo "$basic_machine" | sed 's/^[^-]*-//'`
+-		os=-linux
++		cpu=hppa1.1
++		vendor=hitachi
++		basic_os=hiuxwe2
+ 		;;
+ 	pbd)
+-		basic_machine=sparc-tti
++		cpu=sparc
++		vendor=tti
+ 		;;
+ 	pbb)
+-		basic_machine=m68k-tti
++		cpu=m68k
++		vendor=tti
+ 		;;
+-	pc532 | pc532-*)
+-		basic_machine=ns32k-pc532
++	pc532)
++		cpu=ns32k
++		vendor=pc532
+ 		;;
+-	pc98)
+-		basic_machine=i386-pc
++	pn)
++		cpu=pn
++		vendor=gould
+ 		;;
+-	pc98-*)
+-		basic_machine=i386-`echo "$basic_machine" | sed 's/^[^-]*-//'`
++	power)
++		cpu=power
++		vendor=ibm
+ 		;;
+-	pentium | p5 | k5 | k6 | nexgen | viac3)
+-		basic_machine=i586-pc
++	ps2)
++		cpu=i386
++		vendor=ibm
+ 		;;
+-	pentiumpro | p6 | 6x86 | athlon | athlon_*)
+-		basic_machine=i686-pc
++	rm[46]00)
++		cpu=mips
++		vendor=siemens
+ 		;;
+-	pentiumii | pentium2 | pentiumiii | pentium3)
+-		basic_machine=i686-pc
++	rtpc | rtpc-*)
++		cpu=romp
++		vendor=ibm
+ 		;;
+-	pentium4)
+-		basic_machine=i786-pc
++	sde)
++		cpu=mipsisa32
++		vendor=sde
++		basic_os=${basic_os:-elf}
+ 		;;
+-	pentium-* | p5-* | k5-* | k6-* | nexgen-* | viac3-*)
+-		basic_machine=i586-`echo "$basic_machine" | sed 's/^[^-]*-//'`
++	simso-wrs)
++		cpu=sparclite
++		vendor=wrs
++		basic_os=vxworks
+ 		;;
+-	pentiumpro-* | p6-* | 6x86-* | athlon-*)
+-		basic_machine=i686-`echo "$basic_machine" | sed 's/^[^-]*-//'`
++	tower | tower-32)
++		cpu=m68k
++		vendor=ncr
+ 		;;
+-	pentiumii-* | pentium2-* | pentiumiii-* | pentium3-*)
+-		basic_machine=i686-`echo "$basic_machine" | sed 's/^[^-]*-//'`
++	vpp*|vx|vx-*)
++		cpu=f301
++		vendor=fujitsu
+ 		;;
+-	pentium4-*)
+-		basic_machine=i786-`echo "$basic_machine" | sed 's/^[^-]*-//'`
++	w65)
++		cpu=w65
++		vendor=wdc
+ 		;;
+-	pn)
+-		basic_machine=pn-gould
++	w89k-*)
++		cpu=hppa1.1
++		vendor=winbond
++		basic_os=proelf
+ 		;;
+-	power)	basic_machine=power-ibm
++	none)
++		cpu=none
++		vendor=none
+ 		;;
+-	ppc | ppcbe)	basic_machine=powerpc-unknown
++	leon|leon[3-9])
++		cpu=sparc
++		vendor=$basic_machine
+ 		;;
+-	ppc-* | ppcbe-*)
+-		basic_machine=powerpc-`echo "$basic_machine" | sed 's/^[^-]*-//'`
++	leon-*|leon[3-9]-*)
++		cpu=sparc
++		vendor=`echo "$basic_machine" | sed 's/-.*//'`
+ 		;;
+-	ppcle | powerpclittle)
+-		basic_machine=powerpcle-unknown
++
++	*-*)
++		# shellcheck disable=SC2162
++		saved_IFS=$IFS
++		IFS="-" read cpu vendor <<EOF
++$basic_machine
++EOF
++		IFS=$saved_IFS
+ 		;;
+-	ppcle-* | powerpclittle-*)
+-		basic_machine=powerpcle-`echo "$basic_machine" | sed 's/^[^-]*-//'`
++	# We use 'pc' rather than 'unknown'
++	# because (1) that's what they normally are, and
++	# (2) the word "unknown" tends to confuse beginning users.
++	i*86 | x86_64)
++		cpu=$basic_machine
++		vendor=pc
+ 		;;
+-	ppc64)	basic_machine=powerpc64-unknown
++	# These rules are duplicated from below for sake of the special case above;
++	# i.e. things that normalized to x86 arches should also default to "pc"
++	pc98)
++		cpu=i386
++		vendor=pc
+ 		;;
+-	ppc64-*) basic_machine=powerpc64-`echo "$basic_machine" | sed 's/^[^-]*-//'`
++	x64 | amd64)
++		cpu=x86_64
++		vendor=pc
+ 		;;
+-	ppc64le | powerpc64little)
+-		basic_machine=powerpc64le-unknown
++	# Recognize the basic CPU types without company name.
++	*)
++		cpu=$basic_machine
++		vendor=unknown
+ 		;;
+-	ppc64le-* | powerpc64little-*)
+-		basic_machine=powerpc64le-`echo "$basic_machine" | sed 's/^[^-]*-//'`
++esac
++
++unset -v basic_machine
++
++# Decode basic machines in the full and proper CPU-Company form.
++case $cpu-$vendor in
++	# Here we handle the default manufacturer of certain CPU types in canonical form. It is in
++	# some cases the only manufacturer, in others, it is the most popular.
++	craynv-unknown)
++		vendor=cray
++		basic_os=${basic_os:-unicosmp}
+ 		;;
+-	ps2)
+-		basic_machine=i386-ibm
++	c90-unknown | c90-cray)
++		vendor=cray
++		basic_os=${Basic_os:-unicos}
+ 		;;
+-	pw32)
+-		basic_machine=i586-unknown
+-		os=-pw32
+-		;;
+-	rdos | rdos64)
+-		basic_machine=x86_64-pc
+-		os=-rdos
+-		;;
+-	rdos32)
+-		basic_machine=i386-pc
+-		os=-rdos
+-		;;
+-	rom68k)
+-		basic_machine=m68k-rom68k
+-		os=-coff
++	fx80-unknown)
++		vendor=alliant
+ 		;;
+-	rm[46]00)
+-		basic_machine=mips-siemens
++	romp-unknown)
++		vendor=ibm
+ 		;;
+-	rtpc | rtpc-*)
+-		basic_machine=romp-ibm
++	mmix-unknown)
++		vendor=knuth
+ 		;;
+-	s390 | s390-*)
+-		basic_machine=s390-ibm
++	microblaze-unknown | microblazeel-unknown)
++		vendor=xilinx
+ 		;;
+-	s390x | s390x-*)
+-		basic_machine=s390x-ibm
++	rs6000-unknown)
++		vendor=ibm
+ 		;;
+-	sa29200)
+-		basic_machine=a29k-amd
+-		os=-udi
++	vax-unknown)
++		vendor=dec
+ 		;;
+-	sb1)
+-		basic_machine=mipsisa64sb1-unknown
++	pdp11-unknown)
++		vendor=dec
+ 		;;
+-	sb1el)
+-		basic_machine=mipsisa64sb1el-unknown
++	we32k-unknown)
++		vendor=att
+ 		;;
+-	sde)
+-		basic_machine=mipsisa32-sde
+-		os=-elf
++	cydra-unknown)
++		vendor=cydrome
+ 		;;
+-	sei)
+-		basic_machine=mips-sei
+-		os=-seiux
++	i370-ibm*)
++		vendor=ibm
+ 		;;
+-	sequent)
+-		basic_machine=i386-sequent
++	orion-unknown)
++		vendor=highlevel
+ 		;;
+-	sh5el)
+-		basic_machine=sh5le-unknown
++	xps-unknown | xps100-unknown)
++		cpu=xps100
++		vendor=honeywell
+ 		;;
+-	simso-wrs)
+-		basic_machine=sparclite-wrs
+-		os=-vxworks
++
++	# Here we normalize CPU types with a missing or matching vendor
++	armh-unknown | armh-alt)
++		cpu=armv7l
++		vendor=alt
++		basic_os=${basic_os:-linux-gnueabihf}
+ 		;;
+-	sps7)
+-		basic_machine=m68k-bull
+-		os=-sysv2
+-		;;
+-	spur)
+-		basic_machine=spur-unknown
+-		;;
+-	st2000)
+-		basic_machine=m68k-tandem
+-		;;
+-	stratus)
+-		basic_machine=i860-stratus
+-		os=-sysv4
++	dpx20-unknown | dpx20-bull)
++		cpu=rs6000
++		vendor=bull
++		basic_os=${basic_os:-bosx}
+ 		;;
+-	strongarm-* | thumb-*)
+-		basic_machine=arm-`echo "$basic_machine" | sed 's/^[^-]*-//'`
++
++	# Here we normalize CPU types irrespective of the vendor
++	amd64-*)
++		cpu=x86_64
+ 		;;
+-	sun2)
+-		basic_machine=m68000-sun
++	blackfin-*)
++		cpu=bfin
++		basic_os=linux
+ 		;;
+-	sun2os3)
+-		basic_machine=m68000-sun
+-		os=-sunos3
++	c54x-*)
++		cpu=tic54x
+ 		;;
+-	sun2os4)
+-		basic_machine=m68000-sun
+-		os=-sunos4
++	c55x-*)
++		cpu=tic55x
+ 		;;
+-	sun3os3)
+-		basic_machine=m68k-sun
+-		os=-sunos3
++	c6x-*)
++		cpu=tic6x
++		;;
++	e500v[12]-*)
++		cpu=powerpc
++		basic_os=${basic_os}"spe"
+ 		;;
+-	sun3os4)
+-		basic_machine=m68k-sun
+-		os=-sunos4
++	mips3*-*)
++		cpu=mips64
+ 		;;
+-	sun4os3)
+-		basic_machine=sparc-sun
+-		os=-sunos3
++	ms1-*)
++		cpu=mt
+ 		;;
+-	sun4os4)
+-		basic_machine=sparc-sun
+-		os=-sunos4
++	m68knommu-*)
++		cpu=m68k
++		basic_os=linux
+ 		;;
+-	sun4sol2)
+-		basic_machine=sparc-sun
+-		os=-solaris2
++	m9s12z-* | m68hcs12z-* | hcs12z-* | s12z-*)
++		cpu=s12z
+ 		;;
+-	sun3 | sun3-*)
+-		basic_machine=m68k-sun
++	openrisc-*)
++		cpu=or32
+ 		;;
+-	sun4)
+-		basic_machine=sparc-sun
++	parisc-*)
++		cpu=hppa
++		basic_os=linux
+ 		;;
+-	sun386 | sun386i | roadrunner)
+-		basic_machine=i386-sun
++	pentium-* | p5-* | k5-* | k6-* | nexgen-* | viac3-*)
++		cpu=i586
+ 		;;
+-	sv1)
+-		basic_machine=sv1-cray
+-		os=-unicos
++	pentiumpro-* | p6-* | 6x86-* | athlon-* | athlon_*-*)
++		cpu=i686
+ 		;;
+-	symmetry)
+-		basic_machine=i386-sequent
+-		os=-dynix
++	pentiumii-* | pentium2-* | pentiumiii-* | pentium3-*)
++		cpu=i686
+ 		;;
+-	t3e)
+-		basic_machine=alphaev5-cray
+-		os=-unicos
++	pentium4-*)
++		cpu=i786
+ 		;;
+-	t90)
+-		basic_machine=t90-cray
+-		os=-unicos
++	pc98-*)
++		cpu=i386
+ 		;;
+-	tile*)
+-		basic_machine=$basic_machine-unknown
+-		os=-linux-gnu
++	ppc-* | ppcbe-*)
++		cpu=powerpc
+ 		;;
+-	tx39)
+-		basic_machine=mipstx39-unknown
++	ppcle-* | powerpclittle-*)
++		cpu=powerpcle
+ 		;;
+-	tx39el)
+-		basic_machine=mipstx39el-unknown
++	ppc64-*)
++		cpu=powerpc64
+ 		;;
+-	toad1)
+-		basic_machine=pdp10-xkl
+-		os=-tops20
++	ppc64le-* | powerpc64little-*)
++		cpu=powerpc64le
+ 		;;
+-	tower | tower-32)
+-		basic_machine=m68k-ncr
++	sb1-*)
++		cpu=mipsisa64sb1
+ 		;;
+-	tpf)
+-		basic_machine=s390x-ibm
+-		os=-tpf
+-		;;
+-	udi29k)
+-		basic_machine=a29k-amd
+-		os=-udi
+-		;;
+-	ultra3)
+-		basic_machine=a29k-nyu
+-		os=-sym1
+-		;;
+-	v810 | necv810)
+-		basic_machine=v810-nec
+-		os=-none
+-		;;
+-	vaxv)
+-		basic_machine=vax-dec
+-		os=-sysv
+-		;;
+-	vms)
+-		basic_machine=vax-dec
+-		os=-vms
++	sb1el-*)
++		cpu=mipsisa64sb1el
+ 		;;
+-	vpp*|vx|vx-*)
+-		basic_machine=f301-fujitsu
++	sh5e[lb]-*)
++		cpu=`echo "$cpu" | sed 's/^\(sh.\)e\(.\)$/\1\2e/'`
+ 		;;
+-	vxworks960)
+-		basic_machine=i960-wrs
+-		os=-vxworks
+-		;;
+-	vxworks68)
+-		basic_machine=m68k-wrs
+-		os=-vxworks
+-		;;
+-	vxworks29k)
+-		basic_machine=a29k-wrs
+-		os=-vxworks
+-		;;
+-	w65*)
+-		basic_machine=w65-wdc
+-		os=-none
++	spur-*)
++		cpu=spur
+ 		;;
+-	w89k-*)
+-		basic_machine=hppa1.1-winbond
+-		os=-proelf
++	strongarm-* | thumb-*)
++		cpu=arm
+ 		;;
+-	x64)
+-		basic_machine=x86_64-pc
++	tx39-*)
++		cpu=mipstx39
+ 		;;
+-	xbox)
+-		basic_machine=i686-pc
+-		os=-mingw32
++	tx39el-*)
++		cpu=mipstx39el
+ 		;;
+-	xps | xps100)
+-		basic_machine=xps100-honeywell
++	x64-*)
++		cpu=x86_64
+ 		;;
+ 	xscale-* | xscalee[bl]-*)
+-		basic_machine=`echo "$basic_machine" | sed 's/^xscale/arm/'`
+-		;;
+-	ymp)
+-		basic_machine=ymp-cray
+-		os=-unicos
++		cpu=`echo "$cpu" | sed 's/^xscale/arm/'`
+ 		;;
+-	none)
+-		basic_machine=none-none
+-		os=-none
++	arm64-* | aarch64le-*)
++		cpu=aarch64
+ 		;;
+ 
+-# Here we handle the default manufacturer of certain CPU types.  It is in
+-# some cases the only manufacturer, in others, it is the most popular.
+-	w89k)
+-		basic_machine=hppa1.1-winbond
+-		;;
+-	op50n)
+-		basic_machine=hppa1.1-oki
+-		;;
+-	op60c)
+-		basic_machine=hppa1.1-oki
++	# Recognize the canonical CPU Types that limit and/or modify the
++	# company names they are paired with.
++	cr16-*)
++		basic_os=${basic_os:-elf}
+ 		;;
+-	romp)
+-		basic_machine=romp-ibm
++	crisv32-* | etraxfs*-*)
++		cpu=crisv32
++		vendor=axis
+ 		;;
+-	mmix)
+-		basic_machine=mmix-knuth
++	cris-* | etrax*-*)
++		cpu=cris
++		vendor=axis
+ 		;;
+-	rs6000)
+-		basic_machine=rs6000-ibm
++	crx-*)
++		basic_os=${basic_os:-elf}
+ 		;;
+-	vax)
+-		basic_machine=vax-dec
+-		;;
+-	pdp11)
+-		basic_machine=pdp11-dec
+-		;;
+-	we32k)
+-		basic_machine=we32k-att
+-		;;
+-	sh[1234] | sh[24]a | sh[24]aeb | sh[34]eb | sh[1234]le | sh[23]ele)
+-		basic_machine=sh-unknown
++	neo-tandem)
++		cpu=neo
++		vendor=tandem
+ 		;;
+-	cydra)
+-		basic_machine=cydra-cydrome
++	nse-tandem)
++		cpu=nse
++		vendor=tandem
+ 		;;
+-	orion)
+-		basic_machine=orion-highlevel
++	nsr-tandem)
++		cpu=nsr
++		vendor=tandem
+ 		;;
+-	orion105)
+-		basic_machine=clipper-highlevel
++	nsv-tandem)
++		cpu=nsv
++		vendor=tandem
+ 		;;
+-	mac | mpw | mac-mpw)
+-		basic_machine=m68k-apple
++	nsx-tandem)
++		cpu=nsx
++		vendor=tandem
+ 		;;
+-	pmac | pmac-mpw)
+-		basic_machine=powerpc-apple
++	mipsallegrexel-sony)
++		cpu=mipsallegrexel
++		vendor=sony
+ 		;;
+-	*-unknown)
+-		# Make sure to match an already-canonicalized machine name.
++	tile*-*)
++		basic_os=${basic_os:-linux-gnu}
+ 		;;
++
+ 	*)
+-		echo Invalid configuration \`"$1"\': machine \`"$basic_machine"\' not recognized 1>&2
+-		exit 1
++		# Recognize the canonical CPU types that are allowed with any
++		# company name.
++		case $cpu in
++			1750a | 580 \
++			| a29k \
++			| aarch64 | aarch64_be | aarch64c | arm64ec \
++			| abacus \
++			| alpha | alphaev[4-8] | alphaev56 | alphaev6[78] \
++			| alpha64 | alpha64ev[4-8] | alpha64ev56 | alpha64ev6[78] \
++			| alphapca5[67] | alpha64pca5[67] \
++			| am33_2.0 \
++			| amdgcn \
++			| arc | arceb | arc32 | arc64 \
++			| arm | arm[lb]e | arme[lb] | armv* \
++			| avr | avr32 \
++			| asmjs \
++			| ba \
++			| be32 | be64 \
++			| bfin | bpf | bs2000 \
++			| c[123]* | c30 | [cjt]90 | c4x \
++			| c8051 | clipper | craynv | csky | cydra \
++			| d10v | d30v | dlx | dsp16xx \
++			| e2k | elxsi | epiphany \
++			| f30[01] | f700 | fido | fr30 | frv | ft32 | fx80 \
++			| javascript \
++			| h8300 | h8500 \
++			| hppa | hppa1.[01] | hppa2.0 | hppa2.0[nw] | hppa64 \
++			| hexagon \
++			| i370 | i*86 | i860 | i960 | ia16 | ia64 \
++			| ip2k | iq2000 \
++			| k1om \
++			| kvx \
++			| le32 | le64 \
++			| lm32 \
++			| loongarch32 | loongarch64 \
++			| m32c | m32r | m32rle \
++			| m5200 | m68000 | m680[012346]0 | m68360 | m683?2 | m68k \
++			| m6811 | m68hc11 | m6812 | m68hc12 | m68hcs12x \
++			| m88110 | m88k | maxq | mb | mcore | mep | metag \
++			| microblaze | microblazeel \
++			| mips* \
++			| mmix \
++			| mn10200 | mn10300 \
++			| moxie \
++			| mt \
++			| msp430 \
++			| nanomips* \
++			| nds32 | nds32le | nds32be \
++			| nfp \
++			| nios | nios2 | nios2eb | nios2el \
++			| none | np1 | ns16k | ns32k | nvptx \
++			| open8 \
++			| or1k* \
++			| or32 \
++			| orion \
++			| picochip \
++			| pdp10 | pdp11 | pj | pjl | pn | power \
++			| powerpc | powerpc64 | powerpc64le | powerpcle | powerpcspe \
++			| pru \
++			| pyramid \
++			| riscv | riscv32 | riscv32be | riscv64 | riscv64be \
++			| rl78 | romp | rs6000 | rx \
++			| s390 | s390x \
++			| score \
++			| sh | shl \
++			| sh[1234] | sh[24]a | sh[24]ae[lb] | sh[23]e | she[lb] | sh[lb]e \
++			| sh[1234]e[lb] |  sh[12345][lb]e | sh[23]ele | sh64 | sh64le \
++			| sparc | sparc64 | sparc64b | sparc64v | sparc86x | sparclet \
++			| sparclite \
++			| sparcv8 | sparcv9 | sparcv9b | sparcv9v | sv1 | sx* \
++			| spu \
++			| tahoe \
++			| thumbv7* \
++			| tic30 | tic4x | tic54x | tic55x | tic6x | tic80 \
++			| tron \
++			| ubicom32 \
++			| v70 | v850 | v850e | v850e1 | v850es | v850e2 | v850e2v3 \
++			| vax \
++			| vc4 \
++			| visium \
++			| w65 \
++			| wasm32 | wasm64 \
++			| we32k \
++			| x86 | x86_64 | xc16x | xgate | xps100 \
++			| xstormy16 | xtensa* \
++			| ymp \
++			| z8k | z80)
++				;;
++
++			*)
++				echo "Invalid configuration '$1': machine '$cpu-$vendor' not recognized" 1>&2
++				exit 1
++				;;
++		esac
+ 		;;
+ esac
+ 
+ # Here we canonicalize certain aliases for manufacturers.
+-case $basic_machine in
+-	*-digital*)
+-		basic_machine=`echo "$basic_machine" | sed 's/digital.*/dec/'`
++case $vendor in
++	digital*)
++		vendor=dec
+ 		;;
+-	*-commodore*)
+-		basic_machine=`echo "$basic_machine" | sed 's/commodore.*/cbm/'`
++	commodore*)
++		vendor=cbm
+ 		;;
+ 	*)
+ 		;;
+@@ -1334,203 +1287,226 @@
+ 
+ # Decode manufacturer-specific aliases for certain operating systems.
+ 
+-if [ x"$os" != x"" ]
++if test x"$basic_os" != x
+ then
++
++# First recognize some ad-hoc cases, or perhaps split kernel-os, or else just
++# set os.
++obj=
++case $basic_os in
++	gnu/linux*)
++		kernel=linux
++		os=`echo "$basic_os" | sed -e 's|gnu/linux|gnu|'`
++		;;
++	os2-emx)
++		kernel=os2
++		os=`echo "$basic_os" | sed -e 's|os2-emx|emx|'`
++		;;
++	nto-qnx*)
++		kernel=nto
++		os=`echo "$basic_os" | sed -e 's|nto-qnx|qnx|'`
++		;;
++	*-*)
++		# shellcheck disable=SC2162
++		saved_IFS=$IFS
++		IFS="-" read kernel os <<EOF
++$basic_os
++EOF
++		IFS=$saved_IFS
++		;;
++	# Default OS when just kernel was specified
++	nto*)
++		kernel=nto
++		os=`echo "$basic_os" | sed -e 's|nto|qnx|'`
++		;;
++	linux*)
++		kernel=linux
++		os=`echo "$basic_os" | sed -e 's|linux|gnu|'`
++		;;
++	managarm*)
++		kernel=managarm
++		os=`echo "$basic_os" | sed -e 's|managarm|mlibc|'`
++		;;
++	*)
++		kernel=
++		os=$basic_os
++		;;
++esac
++
++# Now, normalize the OS (knowing we just have one component, it's not a kernel,
++# etc.)
+ case $os in
+ 	# First match some system type aliases that might get confused
+ 	# with valid system types.
+-	# -solaris* is a basic system type, with this one exception.
+-	-auroraux)
+-		os=-auroraux
++	# solaris* is a basic system type, with this one exception.
++	auroraux)
++		os=auroraux
+ 		;;
+-	-solaris1 | -solaris1.*)
+-		os=`echo $os | sed -e 's|solaris1|sunos4|'`
++	bluegene*)
++		os=cnk
+ 		;;
+-	-solaris)
+-		os=-solaris2
++	solaris1 | solaris1.*)
++		os=`echo "$os" | sed -e 's|solaris1|sunos4|'`
+ 		;;
+-	-unixware*)
+-		os=-sysv4.2uw
++	solaris)
++		os=solaris2
+ 		;;
+-	-gnu/linux*)
+-		os=`echo $os | sed -e 's|gnu/linux|linux-gnu|'`
++	unixware*)
++		os=sysv4.2uw
+ 		;;
+ 	# es1800 is here to avoid being matched by es* (a different OS)
+-	-es1800*)
+-		os=-ose
++	es1800*)
++		os=ose
+ 		;;
+-	# Now accept the basic system types.
+-	# The portable systems comes first.
+-	# Each alternative MUST end in a * to match a version number.
+-	# -sysv* is not here because it comes later, after sysvr4.
+-	-gnu* | -bsd* | -mach* | -minix* | -genix* | -ultrix* | -irix* \
+-	      | -*vms* | -sco* | -esix* | -isc* | -aix* | -cnk* | -sunos | -sunos[34]*\
+-	      | -hpux* | -unos* | -osf* | -luna* | -dgux* | -auroraux* | -solaris* \
+-	      | -sym* | -kopensolaris* | -plan9* \
+-	      | -amigaos* | -amigados* | -msdos* | -newsos* | -unicos* | -aof* \
+-	      | -aos* | -aros* | -cloudabi* | -sortix* \
+-	      | -nindy* | -vxsim* | -vxworks* | -ebmon* | -hms* | -mvs* \
+-	      | -clix* | -riscos* | -uniplus* | -iris* | -rtu* | -xenix* \
+-	      | -hiux* | -knetbsd* | -mirbsd* | -netbsd* \
+-	      | -bitrig* | -openbsd* | -solidbsd* | -libertybsd* \
+-	      | -ekkobsd* | -kfreebsd* | -freebsd* | -riscix* | -lynxos* \
+-	      | -bosx* | -nextstep* | -cxux* | -aout* | -elf* | -oabi* \
+-	      | -ptx* | -coff* | -ecoff* | -winnt* | -domain* | -vsta* \
+-	      | -udi* | -eabi* | -lites* | -ieee* | -go32* | -aux* \
+-	      | -chorusos* | -chorusrdb* | -cegcc* | -glidix* \
+-	      | -cygwin* | -msys* | -pe* | -psos* | -moss* | -proelf* | -rtems* \
+-	      | -midipix* | -mingw32* | -mingw64* | -linux-gnu* | -linux-android* \
+-	      | -linux-newlib* | -linux-musl* | -linux-uclibc* \
+-	      | -uxpv* | -beos* | -mpeix* | -udk* | -moxiebox* \
+-	      | -interix* | -uwin* | -mks* | -rhapsody* | -darwin* \
+-	      | -openstep* | -oskit* | -conix* | -pw32* | -nonstopux* \
+-	      | -storm-chaos* | -tops10* | -tenex* | -tops20* | -its* \
+-	      | -os2* | -vos* | -palmos* | -uclinux* | -nucleus* \
+-	      | -morphos* | -superux* | -rtmk* | -windiss* \
+-	      | -powermax* | -dnix* | -nx6 | -nx7 | -sei* | -dragonfly* \
+-	      | -skyos* | -haiku* | -rdos* | -toppers* | -drops* | -es* \
+-	      | -onefs* | -tirtos* | -phoenix* | -fuchsia* | -redox* | -bme* \
+-	      | -midnightbsd*)
+-	# Remember, each alternative MUST END IN *, to match a version number.
+-		;;
+-	-qnx*)
+-		case $basic_machine in
+-		    x86-* | i*86-*)
+-			;;
+-		    *)
+-			os=-nto$os
+-			;;
+-		esac
++	# Some version numbers need modification
++	chorusos*)
++		os=chorusos
+ 		;;
+-	-nto-qnx*)
++	isc)
++		os=isc2.2
+ 		;;
+-	-nto*)
+-		os=`echo $os | sed -e 's|nto|nto-qnx|'`
++	sco6)
++		os=sco5v6
+ 		;;
+-	-sim | -xray | -os68k* | -v88r* \
+-	      | -windows* | -osx | -abug | -netware* | -os9* \
+-	      | -macos* | -mpw* | -magic* | -mmixware* | -mon960* | -lnews*)
++	sco5)
++		os=sco3.2v5
+ 		;;
+-	-mac*)
+-		os=`echo "$os" | sed -e 's|mac|macos|'`
++	sco4)
++		os=sco3.2v4
+ 		;;
+-	-linux-dietlibc)
+-		os=-linux-dietlibc
++	sco3.2.[4-9]*)
++		os=`echo "$os" | sed -e 's/sco3.2./sco3.2v/'`
+ 		;;
+-	-linux*)
+-		os=`echo $os | sed -e 's|linux|linux-gnu|'`
++	sco*v* | scout)
++		# Don't match below
+ 		;;
+-	-sunos5*)
+-		os=`echo "$os" | sed -e 's|sunos5|solaris2|'`
++	sco*)
++		os=sco3.2v2
+ 		;;
+-	-sunos6*)
+-		os=`echo "$os" | sed -e 's|sunos6|solaris3|'`
++	psos*)
++		os=psos
+ 		;;
+-	-opened*)
+-		os=-openedition
++	qnx*)
++		os=qnx
+ 		;;
+-	-os400*)
+-		os=-os400
++	hiux*)
++		os=hiuxwe2
+ 		;;
+-	-wince*)
+-		os=-wince
++	lynx*178)
++		os=lynxos178
+ 		;;
+-	-utek*)
+-		os=-bsd
++	lynx*5)
++		os=lynxos5
+ 		;;
+-	-dynix*)
+-		os=-bsd
++	lynxos*)
++		# don't get caught up in next wildcard
+ 		;;
+-	-acis*)
+-		os=-aos
++	lynx*)
++		os=lynxos
+ 		;;
+-	-atheos*)
+-		os=-atheos
++	mac[0-9]*)
++		os=`echo "$os" | sed -e 's|mac|macos|'`
+ 		;;
+-	-syllable*)
+-		os=-syllable
++	opened*)
++		os=openedition
+ 		;;
+-	-386bsd)
+-		os=-bsd
++	os400*)
++		os=os400
+ 		;;
+-	-ctix* | -uts*)
+-		os=-sysv
++	sunos5*)
++		os=`echo "$os" | sed -e 's|sunos5|solaris2|'`
+ 		;;
+-	-nova*)
+-		os=-rtmk-nova
++	sunos6*)
++		os=`echo "$os" | sed -e 's|sunos6|solaris3|'`
+ 		;;
+-	-ns2)
+-		os=-nextstep2
++	wince*)
++		os=wince
+ 		;;
+-	-nsk*)
+-		os=-nsk
++	utek*)
++		os=bsd
+ 		;;
+-	# Preserve the version number of sinix5.
+-	-sinix5.*)
+-		os=`echo $os | sed -e 's|sinix|sysv|'`
++	dynix*)
++		os=bsd
++		;;
++	acis*)
++		os=aos
++		;;
++	atheos*)
++		os=atheos
++		;;
++	syllable*)
++		os=syllable
++		;;
++	386bsd)
++		os=bsd
++		;;
++	ctix* | uts*)
++		os=sysv
+ 		;;
+-	-sinix*)
+-		os=-sysv4
++	nova*)
++		os=rtmk-nova
+ 		;;
+-	-tpf*)
+-		os=-tpf
++	ns2)
++		os=nextstep2
+ 		;;
+-	-triton*)
+-		os=-sysv3
++	# Preserve the version number of sinix5.
++	sinix5.*)
++		os=`echo "$os" | sed -e 's|sinix|sysv|'`
++		;;
++	sinix*)
++		os=sysv4
+ 		;;
+-	-oss*)
+-		os=-sysv3
++	tpf*)
++		os=tpf
+ 		;;
+-	-svr4*)
+-		os=-sysv4
++	triton*)
++		os=sysv3
+ 		;;
+-	-svr3)
+-		os=-sysv3
++	oss*)
++		os=sysv3
+ 		;;
+-	-sysvr4)
+-		os=-sysv4
++	svr4*)
++		os=sysv4
+ 		;;
+-	# This must come after -sysvr4.
+-	-sysv*)
++	svr3)
++		os=sysv3
+ 		;;
+-	-ose*)
+-		os=-ose
++	sysvr4)
++		os=sysv4
+ 		;;
+-	-*mint | -mint[0-9]* | -*MiNT | -MiNT[0-9]*)
+-		os=-mint
++	ose*)
++		os=ose
+ 		;;
+-	-zvmoe)
+-		os=-zvmoe
++	*mint | mint[0-9]* | *MiNT | MiNT[0-9]*)
++		os=mint
+ 		;;
+-	-dicos*)
+-		os=-dicos
++	dicos*)
++		os=dicos
+ 		;;
+-	-pikeos*)
++	pikeos*)
+ 		# Until real need of OS specific support for
+ 		# particular features comes up, bare metal
+ 		# configurations are quite functional.
+-		case $basic_machine in
++		case $cpu in
+ 		    arm*)
+-			os=-eabi
++			os=eabi
+ 			;;
+ 		    *)
+-			os=-elf
++			os=
++			obj=elf
+ 			;;
+ 		esac
+ 		;;
+-	-nacl*)
+-		;;
+-	-ios)
+-		;;
+-	-none)
++	aout* | coff* | elf* | pe*)
++		# These are machine code file formats, not OSes
++		obj=$os
++		os=
+ 		;;
+ 	*)
+-		# Get rid of the `-' at the beginning of $os.
+-		os=`echo $os | sed 's/[^-]*-//'`
+-		echo Invalid configuration \`"$1"\': system \`"$os"\' not recognized 1>&2
+-		exit 1
++		# No normalization, but not necessarily accepted, that comes below.
+ 		;;
+ esac
++
+ else
+ 
+ # Here we handle the default operating systems that come with various machines.
+@@ -1543,258 +1519,452 @@
+ # will signal an error saying that MANUFACTURER isn't an operating
+ # system, and we'll never get to this point.
+ 
+-case $basic_machine in
++kernel=
++obj=
++case $cpu-$vendor in
+ 	score-*)
+-		os=-elf
++		os=
++		obj=elf
+ 		;;
+ 	spu-*)
+-		os=-elf
++		os=
++		obj=elf
+ 		;;
+ 	*-acorn)
+-		os=-riscix1.2
++		os=riscix1.2
+ 		;;
+ 	arm*-rebel)
+-		os=-linux
++		kernel=linux
++		os=gnu
+ 		;;
+ 	arm*-semi)
+-		os=-aout
++		os=
++		obj=aout
+ 		;;
+ 	c4x-* | tic4x-*)
+-		os=-coff
++		os=
++		obj=coff
+ 		;;
+ 	c8051-*)
+-		os=-elf
++		os=
++		obj=elf
++		;;
++	clipper-intergraph)
++		os=clix
+ 		;;
+ 	hexagon-*)
+-		os=-elf
++		os=
++		obj=elf
+ 		;;
+ 	tic54x-*)
+-		os=-coff
++		os=
++		obj=coff
+ 		;;
+ 	tic55x-*)
+-		os=-coff
++		os=
++		obj=coff
+ 		;;
+ 	tic6x-*)
+-		os=-coff
++		os=
++		obj=coff
+ 		;;
+ 	# This must come before the *-dec entry.
+ 	pdp10-*)
+-		os=-tops20
++		os=tops20
+ 		;;
+ 	pdp11-*)
+-		os=-none
++		os=none
+ 		;;
+ 	*-dec | vax-*)
+-		os=-ultrix4.2
++		os=ultrix4.2
+ 		;;
+ 	m68*-apollo)
+-		os=-domain
++		os=domain
+ 		;;
+ 	i386-sun)
+-		os=-sunos4.0.2
++		os=sunos4.0.2
+ 		;;
+ 	m68000-sun)
+-		os=-sunos3
++		os=sunos3
+ 		;;
+ 	m68*-cisco)
+-		os=-aout
++		os=
++		obj=aout
+ 		;;
+ 	mep-*)
+-		os=-elf
++		os=
++		obj=elf
+ 		;;
+ 	mips*-cisco)
+-		os=-elf
++		os=
++		obj=elf
+ 		;;
+-	mips*-*)
+-		os=-elf
++	mips*-*|nanomips*-*)
++		os=
++		obj=elf
+ 		;;
+ 	or32-*)
+-		os=-coff
++		os=
++		obj=coff
+ 		;;
+ 	*-tti)	# must be before sparc entry or we get the wrong os.
+-		os=-sysv3
++		os=sysv3
+ 		;;
+ 	sparc-* | *-sun)
+-		os=-sunos4.1.1
++		os=sunos4.1.1
+ 		;;
+ 	pru-*)
+-		os=-elf
++		os=
++		obj=elf
+ 		;;
+ 	*-be)
+-		os=-beos
++		os=beos
+ 		;;
+ 	*-ibm)
+-		os=-aix
++		os=aix
+ 		;;
+ 	*-knuth)
+-		os=-mmixware
++		os=mmixware
+ 		;;
+ 	*-wec)
+-		os=-proelf
++		os=proelf
+ 		;;
+ 	*-winbond)
+-		os=-proelf
++		os=proelf
+ 		;;
+ 	*-oki)
+-		os=-proelf
++		os=proelf
+ 		;;
+ 	*-hp)
+-		os=-hpux
++		os=hpux
+ 		;;
+ 	*-hitachi)
+-		os=-hiux
++		os=hiux
+ 		;;
+ 	i860-* | *-att | *-ncr | *-altos | *-motorola | *-convergent)
+-		os=-sysv
++		os=sysv
+ 		;;
+ 	*-cbm)
+-		os=-amigaos
++		os=amigaos
+ 		;;
+ 	*-dg)
+-		os=-dgux
++		os=dgux
+ 		;;
+ 	*-dolphin)
+-		os=-sysv3
++		os=sysv3
+ 		;;
+ 	m68k-ccur)
+-		os=-rtu
++		os=rtu
+ 		;;
+ 	m88k-omron*)
+-		os=-luna
++		os=luna
+ 		;;
+ 	*-next)
+-		os=-nextstep
++		os=nextstep
+ 		;;
+ 	*-sequent)
+-		os=-ptx
++		os=ptx
+ 		;;
+ 	*-crds)
+-		os=-unos
++		os=unos
+ 		;;
+ 	*-ns)
+-		os=-genix
++		os=genix
+ 		;;
+ 	i370-*)
+-		os=-mvs
++		os=mvs
+ 		;;
+ 	*-gould)
+-		os=-sysv
++		os=sysv
+ 		;;
+ 	*-highlevel)
+-		os=-bsd
++		os=bsd
+ 		;;
+ 	*-encore)
+-		os=-bsd
++		os=bsd
+ 		;;
+ 	*-sgi)
+-		os=-irix
++		os=irix
+ 		;;
+ 	*-siemens)
+-		os=-sysv4
++		os=sysv4
+ 		;;
+ 	*-masscomp)
+-		os=-rtu
++		os=rtu
+ 		;;
+ 	f30[01]-fujitsu | f700-fujitsu)
+-		os=-uxpv
++		os=uxpv
+ 		;;
+ 	*-rom68k)
+-		os=-coff
++		os=
++		obj=coff
+ 		;;
+ 	*-*bug)
+-		os=-coff
++		os=
++		obj=coff
+ 		;;
+ 	*-apple)
+-		os=-macos
++		os=macos
+ 		;;
+ 	*-atari*)
+-		os=-mint
++		os=mint
++		;;
++	*-wrs)
++		os=vxworks
+ 		;;
+ 	*)
+-		os=-none
++		os=none
+ 		;;
+ esac
++
+ fi
+ 
++# Now, validate our (potentially fixed-up) individual pieces (OS, OBJ).
++
++case $os in
++	# Sometimes we do "kernel-libc", so those need to count as OSes.
++	llvm* | musl* | newlib* | relibc* | uclibc*)
++		;;
++	# Likewise for "kernel-abi"
++	eabi* | gnueabi*)
++		;;
++	# VxWorks passes extra cpu info in the 4th filed.
++	simlinux | simwindows | spe)
++		;;
++	# See `case $cpu-$os` validation below
++	ghcjs)
++		;;
++	# Now accept the basic system types.
++	# The portable systems comes first.
++	# Each alternative MUST end in a * to match a version number.
++	gnu* | android* | bsd* | mach* | minix* | genix* | ultrix* | irix* \
++	     | *vms* | esix* | aix* | cnk* | sunos | sunos[34]* \
++	     | hpux* | unos* | osf* | luna* | dgux* | auroraux* | solaris* \
++	     | sym* |  plan9* | psp* | sim* | xray* | os68k* | v88r* \
++	     | hiux* | abug | nacl* | netware* | windows* \
++	     | os9* | macos* | osx* | ios* | tvos* | watchos* \
++	     | mpw* | magic* | mmixware* | mon960* | lnews* \
++	     | amigaos* | amigados* | msdos* | newsos* | unicos* | aof* \
++	     | aos* | aros* | cloudabi* | sortix* | twizzler* \
++	     | nindy* | vxsim* | vxworks* | ebmon* | hms* | mvs* \
++	     | clix* | riscos* | uniplus* | iris* | isc* | rtu* | xenix* \
++	     | mirbsd* | netbsd* | dicos* | openedition* | ose* \
++	     | bitrig* | openbsd* | secbsd* | solidbsd* | libertybsd* | os108* \
++	     | ekkobsd* | freebsd* | riscix* | lynxos* | os400* \
++	     | bosx* | nextstep* | cxux* | oabi* \
++	     | ptx* | ecoff* | winnt* | domain* | vsta* \
++	     | udi* | lites* | ieee* | go32* | aux* | hcos* \
++	     | chorusrdb* | cegcc* | glidix* | serenity* \
++	     | cygwin* | msys* | moss* | proelf* | rtems* \
++	     | midipix* | mingw32* | mingw64* | mint* \
++	     | uxpv* | beos* | mpeix* | udk* | moxiebox* \
++	     | interix* | uwin* | mks* | rhapsody* | darwin* \
++	     | openstep* | oskit* | conix* | pw32* | nonstopux* \
++	     | storm-chaos* | tops10* | tenex* | tops20* | its* \
++	     | os2* | vos* | palmos* | uclinux* | nucleus* | morphos* \
++	     | scout* | superux* | sysv* | rtmk* | tpf* | windiss* \
++	     | powermax* | dnix* | nx6 | nx7 | sei* | dragonfly* \
++	     | skyos* | haiku* | rdos* | toppers* | drops* | es* \
++	     | onefs* | tirtos* | phoenix* | fuchsia* | redox* | bme* \
++	     | midnightbsd* | amdhsa* | unleashed* | emscripten* | wasi* \
++	     | nsk* | powerunix* | genode* | zvmoe* | qnx* | emx* | zephyr* \
++	     | fiwix* | mlibc* | cos* | mbr* | ironclad* )
++		;;
++	# This one is extra strict with allowed versions
++	sco3.2v2 | sco3.2v[4-9]* | sco5v6*)
++		# Don't forget version if it is 3.2v4 or newer.
++		;;
++	# This refers to builds using the UEFI calling convention
++	# (which depends on the architecture) and PE file format.
++	# Note that this is both a different calling convention and
++	# different file format than that of GNU-EFI
++	# (x86_64-w64-mingw32).
++	uefi)
++		;;
++	none)
++		;;
++	kernel* | msvc* )
++		# Restricted further below
++		;;
++	'')
++		if test x"$obj" = x
++		then
++			echo "Invalid configuration '$1': Blank OS only allowed with explicit machine code file format" 1>&2
++		fi
++		;;
++	*)
++		echo "Invalid configuration '$1': OS '$os' not recognized" 1>&2
++		exit 1
++		;;
++esac
++
++case $obj in
++	aout* | coff* | elf* | pe*)
++		;;
++	'')
++		# empty is fine
++		;;
++	*)
++		echo "Invalid configuration '$1': Machine code format '$obj' not recognized" 1>&2
++		exit 1
++		;;
++esac
++
++# Here we handle the constraint that a (synthetic) cpu and os are
++# valid only in combination with each other and nowhere else.
++case $cpu-$os in
++	# The "javascript-unknown-ghcjs" triple is used by GHC; we
++	# accept it here in order to tolerate that, but reject any
++	# variations.
++	javascript-ghcjs)
++		;;
++	javascript-* | *-ghcjs)
++		echo "Invalid configuration '$1': cpu '$cpu' is not valid with os '$os$obj'" 1>&2
++		exit 1
++		;;
++esac
++
++# As a final step for OS-related things, validate the OS-kernel combination
++# (given a valid OS), if there is a kernel.
++case $kernel-$os-$obj in
++	linux-gnu*- | linux-android*- | linux-dietlibc*- | linux-llvm*- \
++		    | linux-mlibc*- | linux-musl*- | linux-newlib*- \
++		    | linux-relibc*- | linux-uclibc*- )
++		;;
++	uclinux-uclibc*- )
++		;;
++	managarm-mlibc*- | managarm-kernel*- )
++		;;
++	windows*-msvc*-)
++		;;
++	-dietlibc*- | -llvm*- | -mlibc*- | -musl*- | -newlib*- | -relibc*- \
++		    | -uclibc*- )
++		# These are just libc implementations, not actual OSes, and thus
++		# require a kernel.
++		echo "Invalid configuration '$1': libc '$os' needs explicit kernel." 1>&2
++		exit 1
++		;;
++	-kernel*- )
++		echo "Invalid configuration '$1': '$os' needs explicit kernel." 1>&2
++		exit 1
++		;;
++	*-kernel*- )
++		echo "Invalid configuration '$1': '$kernel' does not support '$os'." 1>&2
++		exit 1
++		;;
++	*-msvc*- )
++		echo "Invalid configuration '$1': '$os' needs 'windows'." 1>&2
++		exit 1
++		;;
++	kfreebsd*-gnu*- | kopensolaris*-gnu*-)
++		;;
++	vxworks-simlinux- | vxworks-simwindows- | vxworks-spe-)
++		;;
++	nto-qnx*-)
++		;;
++	os2-emx-)
++		;;
++	*-eabi*- | *-gnueabi*-)
++		;;
++	none--*)
++		# None (no kernel, i.e. freestanding / bare metal),
++		# can be paired with an machine code file format
++		;;
++	-*-)
++		# Blank kernel with real OS is always fine.
++		;;
++	--*)
++		# Blank kernel and OS with real machine code file format is always fine.
++		;;
++	*-*-*)
++		echo "Invalid configuration '$1': Kernel '$kernel' not known to work with OS '$os'." 1>&2
++		exit 1
++		;;
++esac
++
+ # Here we handle the case where we know the os, and the CPU type, but not the
+ # manufacturer.  We pick the logical manufacturer.
+-vendor=unknown
+-case $basic_machine in
+-	*-unknown)
+-		case $os in
+-			-riscix*)
++case $vendor in
++	unknown)
++		case $cpu-$os in
++			*-riscix*)
+ 				vendor=acorn
+ 				;;
+-			-sunos*)
++			*-sunos*)
+ 				vendor=sun
+ 				;;
+-			-cnk*|-aix*)
++			*-cnk* | *-aix*)
+ 				vendor=ibm
+ 				;;
+-			-beos*)
++			*-beos*)
+ 				vendor=be
+ 				;;
+-			-hpux*)
++			*-hpux*)
+ 				vendor=hp
+ 				;;
+-			-mpeix*)
++			*-mpeix*)
+ 				vendor=hp
+ 				;;
+-			-hiux*)
++			*-hiux*)
+ 				vendor=hitachi
+ 				;;
+-			-unos*)
++			*-unos*)
+ 				vendor=crds
+ 				;;
+-			-dgux*)
++			*-dgux*)
+ 				vendor=dg
+ 				;;
+-			-luna*)
++			*-luna*)
+ 				vendor=omron
+ 				;;
+-			-genix*)
++			*-genix*)
+ 				vendor=ns
+ 				;;
+-			-mvs* | -opened*)
++			*-clix*)
++				vendor=intergraph
++				;;
++			*-mvs* | *-opened*)
++				vendor=ibm
++				;;
++			*-os400*)
+ 				vendor=ibm
+ 				;;
+-			-os400*)
++			s390-* | s390x-*)
+ 				vendor=ibm
+ 				;;
+-			-ptx*)
++			*-ptx*)
+ 				vendor=sequent
+ 				;;
+-			-tpf*)
++			*-tpf*)
+ 				vendor=ibm
+ 				;;
+-			-vxsim* | -vxworks* | -windiss*)
++			*-vxsim* | *-vxworks* | *-windiss*)
+ 				vendor=wrs
+ 				;;
+-			-aux*)
++			*-aux*)
+ 				vendor=apple
+ 				;;
+-			-hms*)
++			*-hms*)
+ 				vendor=hitachi
+ 				;;
+-			-mpw* | -macos*)
++			*-mpw* | *-macos*)
+ 				vendor=apple
+ 				;;
+-			-*mint | -mint[0-9]* | -*MiNT | -MiNT[0-9]*)
++			*-*mint | *-mint[0-9]* | *-*MiNT | *-MiNT[0-9]*)
+ 				vendor=atari
+ 				;;
+-			-vos*)
++			*-vos*)
+ 				vendor=stratus
+ 				;;
+ 		esac
+-		basic_machine=`echo "$basic_machine" | sed "s/unknown/$vendor/"`
+ 		;;
+ esac
+ 
+-echo "$basic_machine$os"
++echo "$cpu-$vendor${kernel:+-$kernel}${os:+-$os}${obj:+-$obj}"
+ exit
+ 
+ # Local variables:
+-# eval: (add-hook 'write-file-functions 'time-stamp)
++# eval: (add-hook 'before-save-hook 'time-stamp)
+ # time-stamp-start: "timestamp='"
+ # time-stamp-format: "%:y-%02m-%02d"
+ # time-stamp-end: "'"


### PR DESCRIPTION
The latest github actions macos-latest runners are reporting `arm64-apple` which the automake files packaged with libyaml do not recognize:

```
checking host system type... Invalid configuration `arm64-apple-darwin23.4.0': machine `arm64-apple' not recognized
configure: error: /bin/sh config/config.sub arm64-apple-darwin23.4.0 failed
```

Update config.guess and config.sub as so many projects have to do everywhere. See https://github.com/sparklemotion/nokogiri/issues/2171#issuecomment-812313353 for more context.