### PR TITLE
ci: pin builds to macos-13

### DIFF
--- a/.github/workflows/packaged_tarball.yml
+++ b/.github/workflows/packaged_tarball.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ["3.0", "3.1", "3.2", "3.3", "head"]
-        runs-on: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        runs-on: ["ubuntu-latest", "macos-13", "windows-latest"]
     runs-on: ${{matrix.runs-on}}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/precompiled.yml
+++ b/.github/workflows/precompiled.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        runs-on: ["ubuntu-latest", "macos-13", "windows-latest"]
         ruby: ["3.0", "3.1", "3.2", "3.3", "head"]
     runs-on: ${{matrix.runs-on}}
     steps:
@@ -66,9 +66,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu", "macos", "windows"]
+        os: ["ubuntu-latest", "macos-13", "windows-latest"]
         ruby: ["3.0", "3.1", "3.2", "3.3", "head"]
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1

--- a/.github/workflows/system.yml
+++ b/.github/workflows/system.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ["3.0", "3.1", "3.2", "3.3", "head"]
-        runs-on: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        runs-on: ["ubuntu-latest", "macos-13", "windows-latest"]
     runs-on: ${{matrix.runs-on}}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
because libyaml 0.2.5 doesn't build cleanly on macos-14 yet for a variety of reasons