### PR TITLE
ci: bump test image tag from 3.4-rc to 3.4

### DIFF
--- a/.github/workflows/isolated.yml
+++ b/.github/workflows/isolated.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3", "head"]
+        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4", "head"]
         runs-on: ["ubuntu-latest", "macos-latest", "windows-latest"]
     runs-on: ${{matrix.runs-on}}
     steps:

--- a/.github/workflows/packaged_source.yml
+++ b/.github/workflows/packaged_source.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3", "head"]
+        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4", "head"]
         runs-on: ["ubuntu-latest", "macos-latest", "windows-latest"]
     runs-on: ${{matrix.runs-on}}
     steps:

--- a/.github/workflows/packaged_tarball.yml
+++ b/.github/workflows/packaged_tarball.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3", "head"]
+        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4", "head"]
         runs-on: ["ubuntu-latest", "macos-13", "windows-latest"]
     runs-on: ${{matrix.runs-on}}
     steps:

--- a/.github/workflows/precompiled.yml
+++ b/.github/workflows/precompiled.yml
@@ -21,8 +21,8 @@ on:
 jobs:
   ruby_versions:
     outputs:
-      setup_ruby: "['3.1', '3.2', '3.3', 'head']"
-      image_tag: "['3.1', '3.2', '3.3', '3.4-rc']"
+      setup_ruby: "['3.1', '3.2', '3.3', '3.4']"
+      image_tag: "['3.1', '3.2', '3.3', '3.4']"
     runs-on: ubuntu-latest
     steps:
       - run: echo "generating rubies ..."

--- a/.github/workflows/system.yml
+++ b/.github/workflows/system.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3", "head"]
+        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4", "head"]
         runs-on: ["ubuntu-latest", "macos-13", "windows-latest"]
     runs-on: ${{matrix.runs-on}}
     steps:


### PR DESCRIPTION
still waiting on rubyinstaller to release 3.4 for windows, so I can't do a general bump of CI to 3.4 for setup-ruby