### PR TITLE
precompiled: drop ruby 3.1 from the packaging

### DIFF
--- a/.github/workflows/precompiled.yml
+++ b/.github/workflows/precompiled.yml
@@ -21,8 +21,8 @@ on:
 jobs:
   ruby_versions:
     outputs:
-      setup_ruby: "['3.1', '3.2', '3.3', '3.4']"
-      image_tag: "['3.1', '3.2', '3.3', '3.4']"
+      setup_ruby: "['3.2', '3.3', '3.4']"
+      image_tag: "['3.2', '3.3', '3.4']"
     runs-on: ubuntu-latest
     steps:
       - run: echo "generating rubies ..."

--- a/precompiled/Rakefile
+++ b/precompiled/Rakefile
@@ -6,7 +6,7 @@ require "rake/testtask"
 require "rake/extensiontask"
 require "rake_compiler_dock"
 
-cross_rubies = ["3.4.1", "3.3.5", "3.2.6", "3.1.6"]
+cross_rubies = ["3.4.1", "3.3.5", "3.2.6"]
 cross_platforms = [
   "aarch64-linux-gnu",
   "aarch64-linux-musl",


### PR DESCRIPTION
Testing the claim from https://github.com/rake-compiler/rake-compiler-dock/issues/145 that dropping Ruby 3.1 leads to build errors.