### PR TITLE
Don't assume shared library is installed relative to files in lib

### DIFF
--- a/isolated/README.md
+++ b/isolated/README.md
@@ -58,8 +58,13 @@ gcc -shared -L/path/to/ruby/lib -lruby -lc -lm isolated.o -o isolated.so
 That final shared library, `isolated.so`, is loaded like any other Ruby file, via `require` in `lib/rcee/isolated.rb`:
 
 ``` ruby
-require_relative "isolated/isolated"
+require "rcee/isolated/isolated"
 ```
+
+Even though RubyGems currently installs shared libraries relatively to Ruby
+files in lib/, it may stop doing so in the future, so it's safer to not load
+shared libraries from Ruby code using `require_relative`, but rather rely on the
+`$LOAD_PATH` and use `require`.
 
 ## Testing
 

--- a/isolated/lib/rcee/isolated.rb
+++ b/isolated/lib/rcee/isolated.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "isolated/version"
-require_relative "isolated/isolated"
+require "rcee/isolated/isolated"
 
 module RCEE
   module Isolated

--- a/packaged_source/lib/rcee/packaged_source.rb
+++ b/packaged_source/lib/rcee/packaged_source.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "packaged_source/version"
-require_relative "packaged_source/packaged_source"
+require "rcee/packaged_source/packaged_source"
 
 module RCEE
   module PackagedSource

--- a/packaged_tarball/lib/rcee/packaged_tarball.rb
+++ b/packaged_tarball/lib/rcee/packaged_tarball.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "packaged_tarball/version"
-require_relative "packaged_tarball/packaged_tarball"
+require "rcee/packaged_tarball/packaged_tarball"
 
 module RCEE
   module PackagedTarball

--- a/precompiled/lib/rcee/precompiled.rb
+++ b/precompiled/lib/rcee/precompiled.rb
@@ -5,7 +5,7 @@ require_relative "precompiled/version"
 begin
   # load the precompiled extension file
   ruby_version = /(\d+\.\d+)/.match(::RUBY_VERSION)
-  require_relative "precompiled/#{ruby_version}/precompiled"
+  require "rcee/precompiled/#{ruby_version}/precompiled"
 rescue LoadError
   # fall back to the extension compiled upon installation.
   # use "require" instead of "require_relative" because non-native gems will place C extension files

--- a/system/lib/rcee/system.rb
+++ b/system/lib/rcee/system.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "system/version"
-require_relative "system/system"
+require "rcee/system/system"
 
 module RCEE
   module System


### PR DESCRIPTION
This currently works, but it's planned to eventually stop doing it. Furthermore, there's  a `.gemrc` configuration
(install_extension_in_lib) that some OS packagers set to false to enable the future behavior, and gems making this assumption don't work with that.

Honestly, it feels like a very hard change for RubyGems to make smoothly and that makes me doubt it's worth doing, but this would be the "blessed way" that should not break regardless of what we end up doing.