### PR TITLE
The `setup-ruby-pkgs` GitHub action now lives in the `ruby` org

### DIFF
--- a/.github/workflows/system.yml
+++ b/.github/workflows/system.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{matrix.runs-on}}
     steps:
       - uses: actions/checkout@v4
-      - uses: MSP-Greg/setup-ruby-pkgs@v1
+      - uses: ruby/setup-ruby-pkgs@v1
         with:
           working-directory: system
           ruby-version: ${{matrix.ruby}}

--- a/system/README.md
+++ b/system/README.md
@@ -86,7 +86,7 @@ See [.github/workflows/system.yml](../.github/workflows/system.yml)
 Key things to note:
 
 - matrix across all supported Rubies and platforms
-- use the github action `MSP-Greg/setup-ruby-pkgs@v1` to install system libraries on each platform
+- use the github action `ruby/setup-ruby-pkgs@v1` to install system libraries on each platform
 
 
 ## What Can Go Wrong


### PR DESCRIPTION
The `setup-ruby-pkgs` GitHub action now lives in the `ruby` [org](https://github.com/ruby/setup-ruby-pkgs) (see https://github.com/ruby/setup-ruby-pkgs/commit/5029fe1dde27fe2f30117943086221db7f43847f)

- Tweaked the README and modified the workflow as I think GitHub may remove that redirection at any point.


PS: Thanks @flavorjones for this amazing resource. As a complete newbie on C extensions this is super useful.