### PR TITLE
ci: fix and update all workflows

### DIFF
--- a/.github/workflows/isolated.yml
+++ b/.github/workflows/isolated.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4", "head"]
+        ruby: ["3.2", "3.3", "3.4", "4.0", "head"]
         runs-on: ["ubuntu-latest", "macos-latest", "windows-latest"]
     runs-on: ${{matrix.runs-on}}
     steps:

--- a/.github/workflows/packaged_source.yml
+++ b/.github/workflows/packaged_source.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4", "head"]
+        ruby: ["3.2", "3.3", "3.4", "4.0", "head"]
         runs-on: ["ubuntu-latest", "macos-latest", "windows-latest"]
     runs-on: ${{matrix.runs-on}}
     steps:

--- a/.github/workflows/packaged_tarball.yml
+++ b/.github/workflows/packaged_tarball.yml
@@ -23,8 +23,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4", "head"]
-        runs-on: ["ubuntu-latest", "macos-13", "windows-latest"]
+        ruby: ["3.2", "3.3", "3.4", "4.0", "head"]
+        runs-on: ["ubuntu-latest", "macos-latest", "windows-latest"]
     runs-on: ${{matrix.runs-on}}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/system.yml
+++ b/.github/workflows/system.yml
@@ -23,8 +23,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4", "head"]
-        runs-on: ["ubuntu-latest", "macos-13", "windows-latest"]
+        ruby: ["3.2", "3.3", "3.4", "4.0", "head"]
+        runs-on: ["ubuntu-latest", "macos-latest", "windows-latest"]
     runs-on: ${{matrix.runs-on}}
     steps:
       - uses: actions/checkout@v4
@@ -36,5 +36,7 @@ jobs:
           mingw: "libyaml" # windows
           apt-get: "libyaml-dev" # linux
           brew: "libyaml" # macos
+      - if: runner.os == 'macOS'
+        run: echo "CONFIGURE_ARGS=--with-libyaml-dir=$(brew --prefix libyaml)" >> $GITHUB_ENV
       - run: bundle exec rake compile test
         working-directory: system


### PR DESCRIPTION
## Summary

- Replace `macos-13` runners with `macos-latest` in system and packaged_tarball workflows (macos-13 is no longer available, all macOS jobs have been cancelled since late 2025)
- Update Ruby matrix across all workflows from `[3.0, 3.1, 3.2, 3.3, 3.4, head]` to `[3.2, 3.3, 3.4, 4.0, head]`
- Pass `CONFIGURE_ARGS` with homebrew libyaml prefix on macOS in the system workflow, so ruby head can find `yaml.h` on ARM runners

The ruby head issue is because `ruby-dev-builder` configures with `--with-openssl-dir` and `--with-readline-dir` but not `--with-opt-dir` for homebrew. On ARM macOS runners homebrew installs to `/opt/homebrew` (not `/usr/local`), which isn't in the default compiler search path.

## Test plan

- [x] All four workflows triggered and passing on fix-ci branch